### PR TITLE
Problem: need basic server design

### DIFF
--- a/include/malamute.h
+++ b/include/malamute.h
@@ -35,5 +35,6 @@
 
 //  Public API
 #include "mlm_msg.h"
+#include "mlm_server.h"
 
 #endif

--- a/include/mlm_msg.h
+++ b/include/mlm_msg.h
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    mlm_msg       - The Malamute Protocol
+    mlm_msg - The Malamute Protocol
     
     Codec header for mlm_msg.
 
@@ -13,7 +13,7 @@
      * The code generation script that built this file: zproto_codec_c
     ************************************************************************
     Copyright (c) the Contributors as noted in the AUTHORS file.       
-    This file is part of MALAMUTE, the ZeroMQ broker project.          
+    This file is part of the Malamute Project.                         
                                                                        
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -24,13 +24,13 @@
 #ifndef __MLM_MSG_H_INCLUDED__
 #define __MLM_MSG_H_INCLUDED__
 
-/*  These are the mlm_msg       messages:
+/*  These are the mlm_msg messages:
 
     CONNECTION_OPEN - Client opens a connection to the server. Client can ask for a mailbox
 by specifying an address. If mailbox does not exist, server creates it.
 Server replies with OK or ERROR.
         protocol            string      Constant "MALAMUTE"
-        version             number  2   Protocol version 1
+        version             number 2    Protocol version 1
         address             string      Client address
 
     CONNECTION_PING - Client pings the server. Server replies with CONNECTION-PONG, or
@@ -79,9 +79,9 @@ delivered within the specified timeout (zero means infinite), the server
 discards it and returns a CONFIRM with a TIMEOUT-EXPIRED status.
         address             string      Mailbox address
         subject             string      Message subject
-        content             msg         Message body frames
         tracking            string      Message tracking ID
-        timeout             number  4   Timeout, msecs, or zero
+        timeout             number 4    Timeout, msecs, or zero
+        content             msg         Message body frames
 
     MAILBOX_DELIVER - Server delivers a mailbox message to client. Note that client does not 
 open its own mailbox for reading; this is implied in CONNECTION-OPEN.
@@ -91,8 +91,8 @@ the same message a second time.
         sender              string      Sending client address
         address             string      Mailbox address
         subject             string      Message subject
-        content             msg         Message body frames
         tracking            string      Message tracking ID
+        content             msg         Message body frames
 
     SERVICE_SEND - Client sends a service request to a service queue. Server replies with
 OK when queued, or ERROR if that failed. If the tracking ID is not
@@ -102,9 +102,9 @@ within the specified timeout (zero means infinite), the server
 discards it and returns CONFIRM with a TIMEOUT-EXPIRED status.
         service             string      Service name
         subject             string      Message subject
-        content             msg         Message body frames
         tracking            string      Message tracking ID
-        timeout             number  4   Timeout, msecs, or zero
+        timeout             number 4    Timeout, msecs, or zero
+        content             msg         Message body frames
 
     SERVICE_OFFER - Worker client offers a named service, specifying a pattern to match
 message subjects. An empty pattern matches anything. A worker can offer
@@ -119,31 +119,31 @@ client's mailbox.
         sender              string      Sending client address
         service             string      Service name
         subject             string      Message subject
-        content             msg         Message body frames
         tracking            string      Message tracking ID
+        content             msg         Message body frames
 
-    OK      - Server replies with success status. Actual status code provides more
+    OK - Server replies with success status. Actual status code provides more
 information. An OK always has a 2xx status code.
-        status_code         number  2   3-digit status code
+        status_code         number 2    3-digit status code
         status_reason       string      Printable explanation
 
-    ERROR   - Server replies with failure status. Actual status code provides more
+    ERROR - Server replies with failure status. Actual status code provides more
 information. An ERROR always has a 3xx, 4xx, or 5xx status code.
-        status_code         number  2   3-digit status code
+        status_code         number 2    3-digit status code
         status_reason       string      Printable explanation
 
-    CREDIT  - Client sends credit to allow delivery of messages. Until the client
+    CREDIT - Client sends credit to allow delivery of messages. Until the client
 sends credit, the server will not deliver messages. The client can send
 further credit at any time. Credit is measured in number of messages.
 Server does not reply to this message. Note that credit applies to all
 stream, mailbox, and service deliveries.
-        amount              number  2   Number of messages
+        amount              number 2    Number of messages
 
     CONFIRM - Client confirms reception of a message, or server forwards this
 confirmation to original sender. If status code is 300 or higher, this
 indicates that the message could not be delivered.
         tracking            string      Message tracking ID
-        status_code         number  2   3-digit status code
+        status_code         number 2    3-digit status code
         status_reason       string      Printable explanation
 */
 
@@ -184,153 +184,153 @@ extern "C" {
 #endif
 
 //  Opaque class structure
-typedef struct _mlm_msg_t       mlm_msg_t;
+typedef struct _mlm_msg_t mlm_msg_t;
 
 //  @interface
 //  Create a new mlm_msg
-mlm_msg_t                            *
-    mlm_msg_new       (int id);
+mlm_msg_t *
+    mlm_msg_new (int id);
 
 //  Destroy the mlm_msg
 void
-    mlm_msg_destroy       (mlm_msg_t       **self_p);
+    mlm_msg_destroy (mlm_msg_t **self_p);
 
-//  Parse a mlm_msg       from zmsg_t. Returns a new object, or NULL if
+//  Parse a mlm_msg from zmsg_t. Returns a new object, or NULL if
 //  the message could not be parsed, or was NULL. Destroys msg and 
 //  nullifies the msg reference.
-mlm_msg_t                            *
-    mlm_msg_decode       (zmsg_t **msg_p);
+mlm_msg_t *
+    mlm_msg_decode (zmsg_t **msg_p);
 
-//  Encode mlm_msg       into zmsg and destroy it. Returns a newly created
+//  Encode mlm_msg into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
-zmsg_t                      *
-    mlm_msg_encode       (mlm_msg_t       **self_p);
+zmsg_t *
+    mlm_msg_encode (mlm_msg_t **self_p);
 
-//  Receive and parse a mlm_msg       from the socket. Returns new object, 
+//  Receive and parse a mlm_msg from the socket. Returns new object, 
 //  or NULL if error. Will block if there's no message waiting.
-mlm_msg_t                            *
-    mlm_msg_recv       (void *input);
+mlm_msg_t *
+    mlm_msg_recv (void *input);
 
-//  Receive and parse a mlm_msg       from the socket. Returns new object, 
+//  Receive and parse a mlm_msg from the socket. Returns new object, 
 //  or NULL either if there was no input waiting, or the recv was interrupted.
-mlm_msg_t                            *
-    mlm_msg_recv_nowait       (void *input);
+mlm_msg_t *
+    mlm_msg_recv_nowait (void *input);
 
-//  Send the mlm_msg       to the output, and destroy it
+//  Send the mlm_msg to the output, and destroy it
 int
-    mlm_msg_send       (mlm_msg_t       **self_p, void *output);
+    mlm_msg_send (mlm_msg_t **self_p, void *output);
 
-//  Send the mlm_msg       to the output, and do not destroy it
+//  Send the mlm_msg to the output, and do not destroy it
 int
-    mlm_msg_send_again       (mlm_msg_t       *self, void *output);
+    mlm_msg_send_again (mlm_msg_t *self, void *output);
 
 //  Encode the CONNECTION_OPEN 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_connection_open (
         const char *address);
 
 //  Encode the CONNECTION_PING 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_connection_ping (
 );
 
 //  Encode the CONNECTION_PONG 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_connection_pong (
 );
 
 //  Encode the CONNECTION_CLOSE 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_connection_close (
 );
 
-//  Encode the STREAM_WRITE    
-zmsg_t                      *
-    mlm_msg_encode_stream_write  (
+//  Encode the STREAM_WRITE 
+zmsg_t *
+    mlm_msg_encode_stream_write (
         const char *stream);
 
-//  Encode the STREAM_READ     
-zmsg_t                      *
-    mlm_msg_encode_stream_read   (
+//  Encode the STREAM_READ 
+zmsg_t *
+    mlm_msg_encode_stream_read (
         const char *stream,
         const char *pattern);
 
-//  Encode the STREAM_PUBLISH  
-zmsg_t                      *
+//  Encode the STREAM_PUBLISH 
+zmsg_t *
     mlm_msg_encode_stream_publish (
         const char *subject,
         zmsg_t *content);
 
-//  Encode the STREAM_DELIVER  
-zmsg_t                      *
+//  Encode the STREAM_DELIVER 
+zmsg_t *
     mlm_msg_encode_stream_deliver (
         const char *stream,
         const char *sender,
         const char *subject,
         zmsg_t *content);
 
-//  Encode the MAILBOX_SEND    
-zmsg_t                      *
-    mlm_msg_encode_mailbox_send  (
+//  Encode the MAILBOX_SEND 
+zmsg_t *
+    mlm_msg_encode_mailbox_send (
         const char *address,
         const char *subject,
-        zmsg_t *content,
         const char *tracking,
-        uint32_t timeout);
+        uint32_t timeout,
+        zmsg_t *content);
 
 //  Encode the MAILBOX_DELIVER 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_mailbox_deliver (
         const char *sender,
         const char *address,
         const char *subject,
-        zmsg_t *content,
-        const char *tracking);
+        const char *tracking,
+        zmsg_t *content);
 
-//  Encode the SERVICE_SEND    
-zmsg_t                      *
-    mlm_msg_encode_service_send  (
+//  Encode the SERVICE_SEND 
+zmsg_t *
+    mlm_msg_encode_service_send (
         const char *service,
         const char *subject,
-        zmsg_t *content,
         const char *tracking,
-        uint32_t timeout);
+        uint32_t timeout,
+        zmsg_t *content);
 
-//  Encode the SERVICE_OFFER   
-zmsg_t                      *
+//  Encode the SERVICE_OFFER 
+zmsg_t *
     mlm_msg_encode_service_offer (
         const char *service,
         const char *pattern);
 
 //  Encode the SERVICE_DELIVER 
-zmsg_t                      *
+zmsg_t *
     mlm_msg_encode_service_deliver (
         const char *sender,
         const char *service,
         const char *subject,
-        zmsg_t *content,
-        const char *tracking);
+        const char *tracking,
+        zmsg_t *content);
 
-//  Encode the OK              
-zmsg_t                      *
-    mlm_msg_encode_ok            (
+//  Encode the OK 
+zmsg_t *
+    mlm_msg_encode_ok (
         uint16_t status_code,
         const char *status_reason);
 
-//  Encode the ERROR           
-zmsg_t                      *
-    mlm_msg_encode_error         (
+//  Encode the ERROR 
+zmsg_t *
+    mlm_msg_encode_error (
         uint16_t status_code,
         const char *status_reason);
 
-//  Encode the CREDIT          
-zmsg_t                      *
-    mlm_msg_encode_credit        (
+//  Encode the CREDIT 
+zmsg_t *
+    mlm_msg_encode_credit (
         uint16_t amount);
 
-//  Encode the CONFIRM         
-zmsg_t                      *
-    mlm_msg_encode_confirm       (
+//  Encode the CONFIRM 
+zmsg_t *
+    mlm_msg_encode_confirm (
         const char *tracking,
         uint16_t status_code,
         const char *status_reason);
@@ -357,44 +357,44 @@ int
 int
     mlm_msg_send_connection_close (void *output);
     
-//  Send the STREAM_WRITE    to the output in one step
+//  Send the STREAM_WRITE to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_stream_write  (void *output,
+    mlm_msg_send_stream_write (void *output,
         const char *stream);
     
-//  Send the STREAM_READ     to the output in one step
+//  Send the STREAM_READ to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_stream_read   (void *output,
+    mlm_msg_send_stream_read (void *output,
         const char *stream,
         const char *pattern);
     
-//  Send the STREAM_PUBLISH  to the output in one step
+//  Send the STREAM_PUBLISH to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
     mlm_msg_send_stream_publish (void *output,
         const char *subject,
-        zmsg_t     *content);
+        zmsg_t *content);
     
-//  Send the STREAM_DELIVER  to the output in one step
+//  Send the STREAM_DELIVER to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
     mlm_msg_send_stream_deliver (void *output,
         const char *stream,
         const char *sender,
         const char *subject,
-        zmsg_t     *content);
+        zmsg_t *content);
     
-//  Send the MAILBOX_SEND    to the output in one step
+//  Send the MAILBOX_SEND to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_mailbox_send  (void *output,
+    mlm_msg_send_mailbox_send (void *output,
         const char *address,
         const char *subject,
-        zmsg_t     *content,
         const char *tracking,
-        uint32_t timeout);
+        uint32_t timeout,
+        zmsg_t *content);
     
 //  Send the MAILBOX_DELIVER to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
@@ -403,20 +403,20 @@ int
         const char *sender,
         const char *address,
         const char *subject,
-        zmsg_t     *content,
-        const char *tracking);
+        const char *tracking,
+        zmsg_t *content);
     
-//  Send the SERVICE_SEND    to the output in one step
+//  Send the SERVICE_SEND to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_service_send  (void *output,
+    mlm_msg_send_service_send (void *output,
         const char *service,
         const char *subject,
-        zmsg_t     *content,
         const char *tracking,
-        uint32_t timeout);
+        uint32_t timeout,
+        zmsg_t *content);
     
-//  Send the SERVICE_OFFER   to the output in one step
+//  Send the SERVICE_OFFER to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
     mlm_msg_send_service_offer (void *output,
@@ -430,138 +430,138 @@ int
         const char *sender,
         const char *service,
         const char *subject,
-        zmsg_t     *content,
-        const char *tracking);
+        const char *tracking,
+        zmsg_t *content);
     
-//  Send the OK              to the output in one step
+//  Send the OK to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_ok            (void *output,
+    mlm_msg_send_ok (void *output,
         uint16_t status_code,
         const char *status_reason);
     
-//  Send the ERROR           to the output in one step
+//  Send the ERROR to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_error         (void *output,
+    mlm_msg_send_error (void *output,
         uint16_t status_code,
         const char *status_reason);
     
-//  Send the CREDIT          to the output in one step
+//  Send the CREDIT to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_credit        (void *output,
+    mlm_msg_send_credit (void *output,
         uint16_t amount);
     
-//  Send the CONFIRM         to the output in one step
+//  Send the CONFIRM to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 int
-    mlm_msg_send_confirm       (void *output,
+    mlm_msg_send_confirm (void *output,
         const char *tracking,
         uint16_t status_code,
         const char *status_reason);
     
-//  Duplicate the mlm_msg       message
-mlm_msg_t                            *
-    mlm_msg_dup       (mlm_msg_t       *self);
+//  Duplicate the mlm_msg message
+mlm_msg_t *
+    mlm_msg_dup (mlm_msg_t *self);
 
 //  Print contents of message to stdout
 void
-    mlm_msg_print       (mlm_msg_t       *self);
+    mlm_msg_print (mlm_msg_t *self);
 
 //  Get/set the message routing id
-zframe_t                      *
-    mlm_msg_routing_id       (mlm_msg_t       *self);
+zframe_t *
+    mlm_msg_routing_id (mlm_msg_t *self);
 void
-    mlm_msg_set_routing_id       (mlm_msg_t       *self, zframe_t *routing_id);
+    mlm_msg_set_routing_id (mlm_msg_t *self, zframe_t *routing_id);
 
-//  Get the mlm_msg       id and printable command
+//  Get the mlm_msg id and printable command
 int
-    mlm_msg_id       (mlm_msg_t       *self);
+    mlm_msg_id (mlm_msg_t *self);
 void
-    mlm_msg_set_id       (mlm_msg_t       *self, int id);
-const                      char *
-    mlm_msg_command       (mlm_msg_t       *self);
+    mlm_msg_set_id (mlm_msg_t *self, int id);
+const char *
+    mlm_msg_command (mlm_msg_t *self);
 
 //  Get/set the address field
-const                      char *
-    mlm_msg_address       (mlm_msg_t       *self);
+const char *
+    mlm_msg_address (mlm_msg_t *self);
 void
-    mlm_msg_set_address       (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_address (mlm_msg_t *self, const char *format, ...);
 
-//  Get/set the stream  field
-const                      char *
-    mlm_msg_stream        (mlm_msg_t       *self);
+//  Get/set the stream field
+const char *
+    mlm_msg_stream (mlm_msg_t *self);
 void
-    mlm_msg_set_stream        (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_stream (mlm_msg_t *self, const char *format, ...);
 
 //  Get/set the pattern field
-const                      char *
-    mlm_msg_pattern       (mlm_msg_t       *self);
+const char *
+    mlm_msg_pattern (mlm_msg_t *self);
 void
-    mlm_msg_set_pattern       (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_pattern (mlm_msg_t *self, const char *format, ...);
 
 //  Get/set the subject field
-const                      char *
-    mlm_msg_subject       (mlm_msg_t       *self);
+const char *
+    mlm_msg_subject (mlm_msg_t *self);
 void
-    mlm_msg_set_subject       (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_subject (mlm_msg_t *self, const char *format, ...);
 
 //  Get a copy of the content field
-zmsg_t                          *
-    mlm_msg_content       (mlm_msg_t       *self);
+zmsg_t *
+    mlm_msg_content (mlm_msg_t *self);
 //  Get the content field and transfer ownership to caller
-zmsg_t                          *
-    mlm_msg_get_content       (mlm_msg_t       *self);
+zmsg_t *
+    mlm_msg_get_content (mlm_msg_t *self);
 //  Set the content field, transferring ownership from caller
 void
-    mlm_msg_set_content       (mlm_msg_t       *self, zmsg_t     **msg_p);
+    mlm_msg_set_content (mlm_msg_t *self, zmsg_t **msg_p);
 
-//  Get/set the sender  field
-const                      char *
-    mlm_msg_sender        (mlm_msg_t       *self);
+//  Get/set the sender field
+const char *
+    mlm_msg_sender (mlm_msg_t *self);
 void
-    mlm_msg_set_sender        (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_sender (mlm_msg_t *self, const char *format, ...);
 
 //  Get/set the tracking field
-const                      char *
-    mlm_msg_tracking      (mlm_msg_t       *self);
+const char *
+    mlm_msg_tracking (mlm_msg_t *self);
 void
-    mlm_msg_set_tracking      (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_tracking (mlm_msg_t *self, const char *format, ...);
 
 //  Get/set the timeout field
 uint32_t
-    mlm_msg_timeout       (mlm_msg_t       *self);
+    mlm_msg_timeout (mlm_msg_t *self);
 void
-    mlm_msg_set_timeout       (mlm_msg_t       *self, uint32_t timeout);
+    mlm_msg_set_timeout (mlm_msg_t *self, uint32_t timeout);
 
 //  Get/set the service field
-const                      char *
-    mlm_msg_service       (mlm_msg_t       *self);
+const char *
+    mlm_msg_service (mlm_msg_t *self);
 void
-    mlm_msg_set_service       (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_service (mlm_msg_t *self, const char *format, ...);
 
 //  Get/set the status_code field
 uint16_t
-    mlm_msg_status_code   (mlm_msg_t       *self);
+    mlm_msg_status_code (mlm_msg_t *self);
 void
-    mlm_msg_set_status_code   (mlm_msg_t       *self, uint16_t status_code);
+    mlm_msg_set_status_code (mlm_msg_t *self, uint16_t status_code);
 
 //  Get/set the status_reason field
-const                      char *
-    mlm_msg_status_reason (mlm_msg_t       *self);
+const char *
+    mlm_msg_status_reason (mlm_msg_t *self);
 void
-    mlm_msg_set_status_reason (mlm_msg_t       *self, const char *format, ...);
+    mlm_msg_set_status_reason (mlm_msg_t *self, const char *format, ...);
 
-//  Get/set the amount  field
+//  Get/set the amount field
 uint16_t
-    mlm_msg_amount        (mlm_msg_t       *self);
+    mlm_msg_amount (mlm_msg_t *self);
 void
-    mlm_msg_set_amount        (mlm_msg_t       *self, uint16_t amount);
+    mlm_msg_set_amount (mlm_msg_t *self, uint16_t amount);
 
 //  Self test of this class
 int
-    mlm_msg_test       (bool verbose);
+    mlm_msg_test (bool verbose);
 //  @end
 
 //  For backwards compatibility with old codecs

--- a/include/mlm_server.h
+++ b/include/mlm_server.h
@@ -1,0 +1,88 @@
+/*  =========================================================================
+    mlm_server - Malamute Server
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: mlm_server.xml, or
+     * The code generation script that built this file: zproto_server_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    This file is part of the Malamute Project.                         
+                                                                       
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    =========================================================================
+*/
+
+#ifndef __MLM_SERVER_H_INCLUDED__
+#define __MLM_SERVER_H_INCLUDED__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//  @interface
+//  To work with mlm_server, use the CZMQ zactor API:
+//
+//  Create new malamute server instance, passing logging prefix:
+//
+//      zactor_t *malamute_server = zactor_new (mlm_server, "myname");
+//  
+//  Destroy malamute server instance
+//
+//      zactor_destroy (&malamute_server);
+//  
+//  Enable verbose logging of commands and activity:
+//
+//      zstr_send (malamute_server, "VERBOSE");
+//
+//  Bind malamute server to specified endpoint. TCP endpoints may specify
+//  the port number as "*" to aquire an ephemeral port:
+//
+//      zstr_sendx (malamute_server, "BIND", endpoint, NULL);
+//
+//  Return assigned port number, specifically when BIND was done using an
+//  an ephemeral port:
+//
+//      zstr_sendx (malamute_server, "PORT", NULL);
+//      char *command, *port_str;
+//      zstr_recvx (malamute_server, &command, &port_str, NULL);
+//      assert (streq (command, "PORT"));
+//
+//  Specify configuration file to load, overwriting any previous loaded
+//  configuration file or options:
+//
+//      zstr_sendx (malamute_server, "CONFIGURE", filename, NULL);
+//
+//  Set configuration path value:
+//
+//      zstr_sendx (malamute_server, "SET", path, value, NULL);
+//    
+//  Send zmsg_t instance to malamute server:
+//
+//      zactor_send (malamute_server, &msg);
+//
+//  Receive zmsg_t instance from malamute server:
+//
+//      zmsg_t *msg = zactor_recv (malamute_server);
+//
+//  This is the mlm_server constructor as a zactor_fn:
+//
+void
+    mlm_server (zsock_t *pipe, void *args);
+
+//  Self test of this class
+void
+    mlm_server_test (bool verbose);
+//  @end
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,10 +5,12 @@ pkgconfig_DATA = libmlm.pc
 
 include_HEADERS = \
 	../include/malamute.h \
-	../include/mlm_msg.h
+	../include/mlm_msg.h \
+	../include/mlm_server.h
 
 libmlm_la_SOURCES = \
-	mlm_msg.c
+	mlm_msg.c \
+	mlm_server.c
 
 AM_CFLAGS = -g
 AM_CPPFLAGS = -I$(top_srcdir)/include
@@ -25,3 +27,4 @@ TESTS = mlm_selftest
 # Produce generated models; do this manually in src directory
 code:
 	gsl -q mlm_msg.xml
+	gsl -q mlm_server.xml

--- a/src/license.xml
+++ b/src/license.xml
@@ -1,6 +1,6 @@
 <license>
 Copyright (c) the Contributors as noted in the AUTHORS file.
-This file is part of MALAMUTE, the ZeroMQ broker project.
+This file is part of the Malamute Project.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/mlm_msg.bnf
+++ b/src/mlm_msg.bnf
@@ -94,12 +94,12 @@ The following ABNF grammar defines the The Malamute Protocol:
     ;  infinite), the server discards it and returns a CONFIRM with a        
     ;  TIMEOUT-EXPIRED status.                                               
 
-    MAILBOX-SEND    = signature %d9 address subject content tracking timeout
+    MAILBOX-SEND    = signature %d9 address subject tracking timeout content
     address         = string                ; Mailbox address
     subject         = string                ; Message subject
-    content         = msg                   ; Message body frames
     tracking        = string                ; Message tracking ID
     timeout         = number-4              ; Timeout, msecs, or zero
+    content         = msg                   ; Message body frames
 
     ;  Server delivers a mailbox message to client. Note that client does not
     ;  open its own mailbox for reading; this is implied in CONNECTION-OPEN. 
@@ -107,12 +107,12 @@ The following ABNF grammar defines the The Malamute Protocol:
     ;  formally accepts delivery of the message, or if the server delivers   
     ;  the same message a second time.                                       
 
-    MAILBOX-DELIVER = signature %d10 sender address subject content tracking
+    MAILBOX-DELIVER = signature %d10 sender address subject tracking content
     sender          = string                ; Sending client address
     address         = string                ; Mailbox address
     subject         = string                ; Message subject
-    content         = msg                   ; Message body frames
     tracking        = string                ; Message tracking ID
+    content         = msg                   ; Message body frames
 
     ;  Client sends a service request to a service queue. Server replies with
     ;  OK when queued, or ERROR if that failed. If the tracking ID is not    
@@ -121,12 +121,12 @@ The following ABNF grammar defines the The Malamute Protocol:
     ;  within the specified timeout (zero means infinite), the server        
     ;  discards it and returns CONFIRM with a TIMEOUT-EXPIRED status.        
 
-    SERVICE-SEND    = signature %d11 service subject content tracking timeout
+    SERVICE-SEND    = signature %d11 service subject tracking timeout content
     service         = string                ; Service name
     subject         = string                ; Message subject
-    content         = msg                   ; Message body frames
     tracking        = string                ; Message tracking ID
     timeout         = number-4              ; Timeout, msecs, or zero
+    content         = msg                   ; Message body frames
 
     ;  Worker client offers a named service, specifying a pattern to match   
     ;  message subjects. An empty pattern matches anything. A worker can     
@@ -142,12 +142,12 @@ The following ABNF grammar defines the The Malamute Protocol:
     ;  delivery of the message. The worker sends replies to the request to   
     ;  the requesting client's mailbox.                                      
 
-    SERVICE-DELIVER = signature %d13 sender service subject content tracking
+    SERVICE-DELIVER = signature %d13 sender service subject tracking content
     sender          = string                ; Sending client address
     service         = string                ; Service name
     subject         = string                ; Message subject
-    content         = msg                   ; Message body frames
     tracking        = string                ; Message tracking ID
+    content         = msg                   ; Message body frames
 
     ;  Server replies with success status. Actual status code provides more  
     ;  information. An OK always has a 2xx status code.                      

--- a/src/mlm_msg.c
+++ b/src/mlm_msg.c
@@ -1,5 +1,5 @@
 /*  =========================================================================
-    mlm_msg       - The Malamute Protocol
+    mlm_msg - The Malamute Protocol
 
     Codec class for mlm_msg.
 
@@ -13,7 +13,7 @@
      * The code generation script that built this file: zproto_codec_c
     ************************************************************************
     Copyright (c) the Contributors as noted in the AUTHORS file.       
-    This file is part of MALAMUTE, the ZeroMQ broker project.          
+    This file is part of the Malamute Project.                         
                                                                        
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -23,7 +23,7 @@
 
 /*
 @header
-    mlm_msg       - The Malamute Protocol
+    mlm_msg - The Malamute Protocol
 @discuss
 @end
 */
@@ -33,9 +33,9 @@
 
 //  Structure of our class
 
-struct _mlm_msg_t       {
+struct _mlm_msg_t {
     zframe_t *routing_id;               //  Routing_id from ROUTER, if any
-    int id;                             //  mlm_msg       message ID
+    int id;                             //  mlm_msg message ID
     byte *needle;                       //  Read/write pointer for serialization
     byte *ceiling;                      //  Valid upper limit for read pointer
     char *protocol;                     //  Constant "MALAMUTE"
@@ -44,7 +44,7 @@ struct _mlm_msg_t       {
     char *stream;                       //  Name of stream
     char *pattern;                      //  Match message subjects
     char *subject;                      //  Message subject
-    zmsg_t     *content;                //  Message body frames
+    zmsg_t *content;                    //  Message body frames
     char *sender;                       //  Sending client address
     char *tracking;                     //  Message tracking ID
     uint32_t timeout;                   //  Timeout, msecs, or zero
@@ -193,10 +193,10 @@ struct _mlm_msg_t       {
 //  --------------------------------------------------------------------------
 //  Create a new mlm_msg
 
-mlm_msg_t       *
-mlm_msg_new       (int id)
+mlm_msg_t *
+mlm_msg_new (int id)
 {
-    mlm_msg_t       *self = (mlm_msg_t       *) zmalloc (sizeof (mlm_msg_t));
+    mlm_msg_t *self = (mlm_msg_t *) zmalloc (sizeof (mlm_msg_t));
     self->id = id;
     return self;
 }
@@ -206,11 +206,11 @@ mlm_msg_new       (int id)
 //  Destroy the mlm_msg
 
 void
-mlm_msg_destroy       (mlm_msg_t       **self_p)
+mlm_msg_destroy (mlm_msg_t **self_p)
 {
     assert (self_p);
     if (*self_p) {
-        mlm_msg_t       *self = *self_p;
+        mlm_msg_t *self = *self_p;
 
         //  Free class properties
         zframe_destroy (&self->routing_id);
@@ -219,7 +219,7 @@ mlm_msg_destroy       (mlm_msg_t       **self_p)
         free (self->stream);
         free (self->pattern);
         free (self->subject);
-        zmsg_destroy     (&self->content);
+        zmsg_destroy (&self->content);
         free (self->sender);
         free (self->tracking);
         free (self->service);
@@ -233,19 +233,19 @@ mlm_msg_destroy       (mlm_msg_t       **self_p)
 
 
 //  --------------------------------------------------------------------------
-//  Parse a mlm_msg       from zmsg_t. Returns a new object, or NULL if
+//  Parse a mlm_msg from zmsg_t. Returns a new object, or NULL if
 //  the message could not be parsed, or was NULL. Destroys msg and 
 //  nullifies the msg reference.
 
-mlm_msg_t       *
-mlm_msg_decode       (zmsg_t **msg_p)
+mlm_msg_t *
+mlm_msg_decode (zmsg_t **msg_p)
 {
     assert (msg_p);
     zmsg_t *msg = *msg_p;
     if (msg == NULL)
         return NULL;
         
-    mlm_msg_t       *self = mlm_msg_new       (0);
+    mlm_msg_t *self = mlm_msg_new (0);
     //  Read and parse command in frame
     zframe_t *frame = zmsg_pop (msg);
     if (!frame) 
@@ -267,7 +267,7 @@ mlm_msg_decode       (zmsg_t **msg_p)
             GET_STRING (self->protocol);
             if (strneq (self->protocol, "MALAMUTE"))
                 goto malformed;
-            GET_NUMBER2       (self->version);
+            GET_NUMBER2 (self->version);
             if (self->version != 1)
                 goto malformed;
             GET_STRING (self->address);
@@ -314,37 +314,37 @@ mlm_msg_decode       (zmsg_t **msg_p)
         case MLM_MSG_MAILBOX_SEND:
             GET_STRING (self->address);
             GET_STRING (self->subject);
+            GET_STRING (self->tracking);
+            GET_NUMBER4 (self->timeout);
             //  Get zero or more remaining frames, leaving current
             //  frame untouched
             self->content = zmsg_new ();
             while (zmsg_size (msg))
                 zmsg_add (self->content, zmsg_pop (msg));
-            GET_STRING (self->tracking);
-            GET_NUMBER4       (self->timeout);
             break;
 
         case MLM_MSG_MAILBOX_DELIVER:
             GET_STRING (self->sender);
             GET_STRING (self->address);
             GET_STRING (self->subject);
+            GET_STRING (self->tracking);
             //  Get zero or more remaining frames, leaving current
             //  frame untouched
             self->content = zmsg_new ();
             while (zmsg_size (msg))
                 zmsg_add (self->content, zmsg_pop (msg));
-            GET_STRING (self->tracking);
             break;
 
         case MLM_MSG_SERVICE_SEND:
             GET_STRING (self->service);
             GET_STRING (self->subject);
+            GET_STRING (self->tracking);
+            GET_NUMBER4 (self->timeout);
             //  Get zero or more remaining frames, leaving current
             //  frame untouched
             self->content = zmsg_new ();
             while (zmsg_size (msg))
                 zmsg_add (self->content, zmsg_pop (msg));
-            GET_STRING (self->tracking);
-            GET_NUMBER4       (self->timeout);
             break;
 
         case MLM_MSG_SERVICE_OFFER:
@@ -356,31 +356,31 @@ mlm_msg_decode       (zmsg_t **msg_p)
             GET_STRING (self->sender);
             GET_STRING (self->service);
             GET_STRING (self->subject);
+            GET_STRING (self->tracking);
             //  Get zero or more remaining frames, leaving current
             //  frame untouched
             self->content = zmsg_new ();
             while (zmsg_size (msg))
                 zmsg_add (self->content, zmsg_pop (msg));
-            GET_STRING (self->tracking);
             break;
 
         case MLM_MSG_OK:
-            GET_NUMBER2       (self->status_code);
+            GET_NUMBER2 (self->status_code);
             GET_STRING (self->status_reason);
             break;
 
         case MLM_MSG_ERROR:
-            GET_NUMBER2       (self->status_code);
+            GET_NUMBER2 (self->status_code);
             GET_STRING (self->status_reason);
             break;
 
         case MLM_MSG_CREDIT:
-            GET_NUMBER2       (self->amount);
+            GET_NUMBER2 (self->amount);
             break;
 
         case MLM_MSG_CONFIRM:
             GET_STRING (self->tracking);
-            GET_NUMBER2       (self->status_code);
+            GET_NUMBER2 (self->status_code);
             GET_STRING (self->status_reason);
             break;
 
@@ -394,26 +394,26 @@ mlm_msg_decode       (zmsg_t **msg_p)
 
     //  Error returns
     malformed:
-        zsys_error ("malformed message '%d'\n",  self->id);
+        zsys_error ("malformed message '%d'\n", self->id);
     empty:
         zframe_destroy (&frame);
         zmsg_destroy (msg_p);
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
         return (NULL);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode mlm_msg       into zmsg and destroy it. Returns a newly created
+//  Encode mlm_msg into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
 
 zmsg_t *
-mlm_msg_encode       (mlm_msg_t       **self_p)
+mlm_msg_encode (mlm_msg_t **self_p)
 {
     assert (self_p);
     assert (*self_p);
     
-    mlm_msg_t       *self = *self_p;
+    mlm_msg_t *self = *self_p;
     zmsg_t *msg = zmsg_new ();
 
     size_t frame_size = 2 + 1;          //  Signature and message ID
@@ -421,7 +421,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         case MLM_MSG_CONNECTION_OPEN:
             //  protocol is a string with 1-byte length
             frame_size += 1 + strlen ("MALAMUTE");
-            //  version is a 2-byte       integer
+            //  version is a 2-byte integer
             frame_size += 2;
             //  address is a string with 1-byte length
             frame_size++;       //  Size is one octet
@@ -439,14 +439,14 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_STREAM_WRITE:
-            //  stream  is a string with 1-byte length
+            //  stream is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->stream)
                 frame_size += strlen (self->stream);
             break;
             
         case MLM_MSG_STREAM_READ:
-            //  stream  is a string with 1-byte length
+            //  stream is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->stream)
                 frame_size += strlen (self->stream);
@@ -464,11 +464,11 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_STREAM_DELIVER:
-            //  stream  is a string with 1-byte length
+            //  stream is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->stream)
                 frame_size += strlen (self->stream);
-            //  sender  is a string with 1-byte length
+            //  sender is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->sender)
                 frame_size += strlen (self->sender);
@@ -491,12 +491,12 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             frame_size++;       //  Size is one octet
             if (self->tracking)
                 frame_size += strlen (self->tracking);
-            //  timeout is a 4-byte       integer
+            //  timeout is a 4-byte integer
             frame_size += 4;
             break;
             
         case MLM_MSG_MAILBOX_DELIVER:
-            //  sender  is a string with 1-byte length
+            //  sender is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->sender)
                 frame_size += strlen (self->sender);
@@ -527,7 +527,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             frame_size++;       //  Size is one octet
             if (self->tracking)
                 frame_size += strlen (self->tracking);
-            //  timeout is a 4-byte       integer
+            //  timeout is a 4-byte integer
             frame_size += 4;
             break;
             
@@ -543,7 +543,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_SERVICE_DELIVER:
-            //  sender  is a string with 1-byte length
+            //  sender is a string with 1-byte length
             frame_size++;       //  Size is one octet
             if (self->sender)
                 frame_size += strlen (self->sender);
@@ -562,7 +562,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_OK:
-            //  status_code is a 2-byte   integer
+            //  status_code is a 2-byte integer
             frame_size += 2;
             //  status_reason is a string with 1-byte length
             frame_size++;       //  Size is one octet
@@ -571,7 +571,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_ERROR:
-            //  status_code is a 2-byte   integer
+            //  status_code is a 2-byte integer
             frame_size += 2;
             //  status_reason is a string with 1-byte length
             frame_size++;       //  Size is one octet
@@ -580,7 +580,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         case MLM_MSG_CREDIT:
-            //  amount  is a 2-byte       integer
+            //  amount is a 2-byte integer
             frame_size += 2;
             break;
             
@@ -589,7 +589,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             frame_size++;       //  Size is one octet
             if (self->tracking)
                 frame_size += strlen (self->tracking);
-            //  status_code is a 2-byte   integer
+            //  status_code is a 2-byte integer
             frame_size += 2;
             //  status_reason is a string with 1-byte length
             frame_size++;       //  Size is one octet
@@ -598,7 +598,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
             
         default:
-            zsys_error ("bad message type '%d', not sent\n",  self->id);
+            zsys_error ("bad message type '%d', not sent\n", self->id);
             //  No recovery, this is a fatal application error
             assert (false);
     }
@@ -611,7 +611,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
     switch (self->id) {
         case MLM_MSG_CONNECTION_OPEN:
             PUT_STRING ("MALAMUTE");
-            PUT_NUMBER2       (1);
+            PUT_NUMBER2 (1);
             if (self->address) {
                 PUT_STRING (self->address);
             }
@@ -629,7 +629,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_STREAM_WRITE:
-            if (self->stream)  {
+            if (self->stream) {
                 PUT_STRING (self->stream);
             }
             else
@@ -637,7 +637,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_STREAM_READ:
-            if (self->stream)  {
+            if (self->stream) {
                 PUT_STRING (self->stream);
             }
             else
@@ -658,12 +658,12 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_STREAM_DELIVER:
-            if (self->stream)  {
+            if (self->stream) {
                 PUT_STRING (self->stream);
             }
             else
                 PUT_NUMBER1 (0);    //  Empty string
-            if (self->sender)  {
+            if (self->sender) {
                 PUT_STRING (self->sender);
             }
             else
@@ -691,11 +691,11 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             }
             else
                 PUT_NUMBER1 (0);    //  Empty string
-            PUT_NUMBER4       (self->timeout);
+            PUT_NUMBER4 (self->timeout);
             break;
 
         case MLM_MSG_MAILBOX_DELIVER:
-            if (self->sender)  {
+            if (self->sender) {
                 PUT_STRING (self->sender);
             }
             else
@@ -733,7 +733,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             }
             else
                 PUT_NUMBER1 (0);    //  Empty string
-            PUT_NUMBER4       (self->timeout);
+            PUT_NUMBER4 (self->timeout);
             break;
 
         case MLM_MSG_SERVICE_OFFER:
@@ -750,7 +750,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_SERVICE_DELIVER:
-            if (self->sender)  {
+            if (self->sender) {
                 PUT_STRING (self->sender);
             }
             else
@@ -773,7 +773,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_OK:
-            PUT_NUMBER2       (self->status_code);
+            PUT_NUMBER2 (self->status_code);
             if (self->status_reason) {
                 PUT_STRING (self->status_reason);
             }
@@ -782,7 +782,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_ERROR:
-            PUT_NUMBER2       (self->status_code);
+            PUT_NUMBER2 (self->status_code);
             if (self->status_reason) {
                 PUT_STRING (self->status_reason);
             }
@@ -791,7 +791,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             break;
 
         case MLM_MSG_CREDIT:
-            PUT_NUMBER2       (self->amount);
+            PUT_NUMBER2 (self->amount);
             break;
 
         case MLM_MSG_CONFIRM:
@@ -800,7 +800,7 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             }
             else
                 PUT_NUMBER1 (0);    //  Empty string
-            PUT_NUMBER2       (self->status_code);
+            PUT_NUMBER2 (self->status_code);
             if (self->status_reason) {
                 PUT_STRING (self->status_reason);
             }
@@ -812,12 +812,12 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
     //  Now send the data frame
     if (zmsg_append (msg, &frame)) {
         zmsg_destroy (&msg);
-        mlm_msg_destroy       (self_p);
+        mlm_msg_destroy (self_p);
         return NULL;
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_STREAM_PUBLISH)        {
-        if (self->content)       {
+    if (self->id == MLM_MSG_STREAM_PUBLISH) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -830,8 +830,8 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         }
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_STREAM_DELIVER)        {
-        if (self->content)       {
+    if (self->id == MLM_MSG_STREAM_DELIVER) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -844,8 +844,8 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         }
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_MAILBOX_SEND)          {
-        if (self->content)       {
+    if (self->id == MLM_MSG_MAILBOX_SEND) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -858,8 +858,8 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         }
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_MAILBOX_DELIVER)       {
-        if (self->content)       {
+    if (self->id == MLM_MSG_MAILBOX_DELIVER) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -872,8 +872,8 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         }
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_SERVICE_SEND)          {
-        if (self->content)       {
+    if (self->id == MLM_MSG_SERVICE_SEND) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -886,8 +886,8 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
         }
     }
     //  Now send the message field if there is any
-    if (self->id == MLM_MSG_SERVICE_DELIVER)       {
-        if (self->content)       {
+    if (self->id == MLM_MSG_SERVICE_DELIVER) {
+        if (self->content) {
             zframe_t *frame = zmsg_pop (self->content);
             while (frame) {
                 zmsg_append (msg, &frame);
@@ -899,18 +899,18 @@ mlm_msg_encode       (mlm_msg_t       **self_p)
             zmsg_append (msg, &frame);
         }
     }
-    //  Destroy mlm_msg       object
-    mlm_msg_destroy       (self_p);
+    //  Destroy mlm_msg object
+    mlm_msg_destroy (self_p);
     return msg;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Receive and parse a mlm_msg       from the socket. Returns new object or
+//  Receive and parse a mlm_msg from the socket. Returns new object or
 //  NULL if error. Will block if there's no message waiting.
 
-mlm_msg_t       *
-mlm_msg_recv       (void *input)
+mlm_msg_t *
+mlm_msg_recv (void *input)
 {
     assert (input);
     zmsg_t *msg = zmsg_recv (input);
@@ -924,20 +924,20 @@ mlm_msg_recv       (void *input)
         if (!routing_id || !zmsg_next (msg))
             return NULL;        //  Malformed or empty
     }
-    mlm_msg_t       *mlm_msg       = mlm_msg_decode       (&msg);
-    if (mlm_msg       && zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
-        mlm_msg->routing_id       = routing_id;
+    mlm_msg_t *mlm_msg = mlm_msg_decode (&msg);
+    if (mlm_msg && zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
+        mlm_msg->routing_id = routing_id;
 
     return mlm_msg;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Receive and parse a mlm_msg       from the socket. Returns new object,
+//  Receive and parse a mlm_msg from the socket. Returns new object,
 //  or NULL either if there was no input waiting, or the recv was interrupted.
 
-mlm_msg_t       *
-mlm_msg_recv_nowait       (void *input)
+mlm_msg_t *
+mlm_msg_recv_nowait (void *input)
 {
     assert (input);
     zmsg_t *msg = zmsg_recv_nowait (input);
@@ -951,32 +951,32 @@ mlm_msg_recv_nowait       (void *input)
         if (!routing_id || !zmsg_next (msg))
             return NULL;        //  Malformed or empty
     }
-    mlm_msg_t       *mlm_msg       = mlm_msg_decode       (&msg);
-    if (mlm_msg       && zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
-        mlm_msg->routing_id       = routing_id;
+    mlm_msg_t *mlm_msg = mlm_msg_decode (&msg);
+    if (mlm_msg && zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
+        mlm_msg->routing_id = routing_id;
 
     return mlm_msg;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the mlm_msg       to the socket, and destroy it
+//  Send the mlm_msg to the socket, and destroy it
 //  Returns 0 if OK, else -1
 
 int
-mlm_msg_send       (mlm_msg_t       **self_p, void *output)
+mlm_msg_send (mlm_msg_t **self_p, void *output)
 {
     assert (self_p);
     assert (*self_p);
     assert (output);
 
     //  Save routing_id if any, as encode will destroy it
-    mlm_msg_t       *self = *self_p;
+    mlm_msg_t *self = *self_p;
     zframe_t *routing_id = self->routing_id;
     self->routing_id = NULL;
 
-    //  Encode mlm_msg       message to a single zmsg
-    zmsg_t *msg = mlm_msg_encode       (self_p);
+    //  Encode mlm_msg message to a single zmsg
+    zmsg_t *msg = mlm_msg_encode (self_p);
     
     //  If we're sending to a ROUTER, send the routing_id first
     if (zsocket_type (zsock_resolve (output)) == ZMQ_ROUTER) {
@@ -994,15 +994,15 @@ mlm_msg_send       (mlm_msg_t       **self_p, void *output)
 
 
 //  --------------------------------------------------------------------------
-//  Send the mlm_msg       to the output, and do not destroy it
+//  Send the mlm_msg to the output, and do not destroy it
 
 int
-mlm_msg_send_again       (mlm_msg_t       *self, void *output)
+mlm_msg_send_again (mlm_msg_t *self, void *output)
 {
     assert (self);
     assert (output);
-    self = mlm_msg_dup       (self);
-    return mlm_msg_send       (&self, output);
+    self = mlm_msg_dup (self);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1013,9 +1013,9 @@ zmsg_t *
 mlm_msg_encode_connection_open (
     const char *address)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_OPEN);
-    mlm_msg_set_address       (self, address);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_OPEN);
+    mlm_msg_set_address (self, address);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1026,8 +1026,8 @@ zmsg_t *
 mlm_msg_encode_connection_ping (
 )
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_PING);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_PING);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1038,8 +1038,8 @@ zmsg_t *
 mlm_msg_encode_connection_pong (
 )
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_PONG);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_PONG);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1050,94 +1050,94 @@ zmsg_t *
 mlm_msg_encode_connection_close (
 )
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_CLOSE);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_CLOSE);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode STREAM_WRITE    message
+//  Encode STREAM_WRITE message
 
 zmsg_t * 
-mlm_msg_encode_stream_write  (
+mlm_msg_encode_stream_write (
     const char *stream)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_WRITE);
-    mlm_msg_set_stream        (self, stream);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_WRITE);
+    mlm_msg_set_stream (self, stream);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode STREAM_READ     message
+//  Encode STREAM_READ message
 
 zmsg_t * 
-mlm_msg_encode_stream_read   (
+mlm_msg_encode_stream_read (
     const char *stream,
     const char *pattern)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_READ);
-    mlm_msg_set_stream        (self, stream);
-    mlm_msg_set_pattern       (self, pattern);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_READ);
+    mlm_msg_set_stream (self, stream);
+    mlm_msg_set_pattern (self, pattern);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode STREAM_PUBLISH  message
+//  Encode STREAM_PUBLISH message
 
 zmsg_t * 
 mlm_msg_encode_stream_publish (
     const char *subject,
-    zmsg_t     *content)
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_PUBLISH);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_PUBLISH);
+    mlm_msg_set_subject (self, subject);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode STREAM_DELIVER  message
+//  Encode STREAM_DELIVER message
 
 zmsg_t * 
 mlm_msg_encode_stream_deliver (
     const char *stream,
     const char *sender,
     const char *subject,
-    zmsg_t     *content)
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_DELIVER);
-    mlm_msg_set_stream        (self, stream);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_DELIVER);
+    mlm_msg_set_stream (self, stream);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_subject (self, subject);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode MAILBOX_SEND    message
+//  Encode MAILBOX_SEND message
 
 zmsg_t * 
-mlm_msg_encode_mailbox_send  (
+mlm_msg_encode_mailbox_send (
     const char *address,
     const char *subject,
-    zmsg_t     *content,
     const char *tracking,
-    uint32_t timeout)
+    uint32_t timeout,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_MAILBOX_SEND);
-    mlm_msg_set_address       (self, address);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_timeout       (self, timeout);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_MAILBOX_SEND);
+    mlm_msg_set_address (self, address);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_timeout (self, timeout);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1149,54 +1149,54 @@ mlm_msg_encode_mailbox_deliver (
     const char *sender,
     const char *address,
     const char *subject,
-    zmsg_t     *content,
-    const char *tracking)
+    const char *tracking,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_MAILBOX_DELIVER);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_address       (self, address);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_MAILBOX_DELIVER);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_address (self, address);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode SERVICE_SEND    message
+//  Encode SERVICE_SEND message
 
 zmsg_t * 
-mlm_msg_encode_service_send  (
+mlm_msg_encode_service_send (
     const char *service,
     const char *subject,
-    zmsg_t     *content,
     const char *tracking,
-    uint32_t timeout)
+    uint32_t timeout,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_SEND);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_timeout       (self, timeout);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_SEND);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_timeout (self, timeout);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode SERVICE_OFFER   message
+//  Encode SERVICE_OFFER message
 
 zmsg_t * 
 mlm_msg_encode_service_offer (
     const char *service,
     const char *pattern)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_OFFER);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_pattern       (self, pattern);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_OFFER);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_pattern (self, pattern);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1208,77 +1208,77 @@ mlm_msg_encode_service_deliver (
     const char *sender,
     const char *service,
     const char *subject,
-    zmsg_t     *content,
-    const char *tracking)
+    const char *tracking,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_DELIVER);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_DELIVER);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode OK              message
+//  Encode OK message
 
 zmsg_t * 
-mlm_msg_encode_ok            (
+mlm_msg_encode_ok (
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_OK);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_OK);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_encode       (&self);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode ERROR           message
+//  Encode ERROR message
 
 zmsg_t * 
-mlm_msg_encode_error         (
+mlm_msg_encode_error (
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_ERROR);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_ERROR);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_encode       (&self);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode CREDIT          message
+//  Encode CREDIT message
 
 zmsg_t * 
-mlm_msg_encode_credit        (
+mlm_msg_encode_credit (
     uint16_t amount)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CREDIT);
-    mlm_msg_set_amount        (self, amount);
-    return mlm_msg_encode       (&self);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CREDIT);
+    mlm_msg_set_amount (self, amount);
+    return mlm_msg_encode (&self);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Encode CONFIRM         message
+//  Encode CONFIRM message
 
 zmsg_t * 
-mlm_msg_encode_confirm       (
+mlm_msg_encode_confirm (
     const char *tracking,
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONFIRM);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONFIRM);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_encode       (&self);
+    return mlm_msg_encode (&self);
 }
 
 
@@ -1290,9 +1290,9 @@ mlm_msg_send_connection_open (
     void *output,
     const char *address)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_OPEN);
-    mlm_msg_set_address       (self, address);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_OPEN);
+    mlm_msg_set_address (self, address);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1303,8 +1303,8 @@ int
 mlm_msg_send_connection_ping (
     void *output)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_PING);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_PING);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1315,8 +1315,8 @@ int
 mlm_msg_send_connection_pong (
     void *output)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_PONG);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_PONG);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1327,60 +1327,60 @@ int
 mlm_msg_send_connection_close (
     void *output)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONNECTION_CLOSE);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONNECTION_CLOSE);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the STREAM_WRITE    to the socket in one step
+//  Send the STREAM_WRITE to the socket in one step
 
 int
-mlm_msg_send_stream_write  (
+mlm_msg_send_stream_write (
     void *output,
     const char *stream)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_WRITE);
-    mlm_msg_set_stream        (self, stream);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_WRITE);
+    mlm_msg_set_stream (self, stream);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the STREAM_READ     to the socket in one step
+//  Send the STREAM_READ to the socket in one step
 
 int
-mlm_msg_send_stream_read   (
+mlm_msg_send_stream_read (
     void *output,
     const char *stream,
     const char *pattern)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_READ);
-    mlm_msg_set_stream        (self, stream);
-    mlm_msg_set_pattern       (self, pattern);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_READ);
+    mlm_msg_set_stream (self, stream);
+    mlm_msg_set_pattern (self, pattern);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the STREAM_PUBLISH  to the socket in one step
+//  Send the STREAM_PUBLISH to the socket in one step
 
 int
 mlm_msg_send_stream_publish (
     void *output,
     const char *subject,
-    zmsg_t     *content)
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_PUBLISH);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_PUBLISH);
+    mlm_msg_set_subject (self, subject);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the STREAM_DELIVER  to the socket in one step
+//  Send the STREAM_DELIVER to the socket in one step
 
 int
 mlm_msg_send_stream_deliver (
@@ -1388,38 +1388,38 @@ mlm_msg_send_stream_deliver (
     const char *stream,
     const char *sender,
     const char *subject,
-    zmsg_t     *content)
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_STREAM_DELIVER);
-    mlm_msg_set_stream        (self, stream);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_STREAM_DELIVER);
+    mlm_msg_set_stream (self, stream);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_subject (self, subject);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the MAILBOX_SEND    to the socket in one step
+//  Send the MAILBOX_SEND to the socket in one step
 
 int
-mlm_msg_send_mailbox_send  (
+mlm_msg_send_mailbox_send (
     void *output,
     const char *address,
     const char *subject,
-    zmsg_t     *content,
     const char *tracking,
-    uint32_t timeout)
+    uint32_t timeout,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_MAILBOX_SEND);
-    mlm_msg_set_address       (self, address);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_timeout       (self, timeout);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_MAILBOX_SEND);
+    mlm_msg_set_address (self, address);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_timeout (self, timeout);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1432,45 +1432,45 @@ mlm_msg_send_mailbox_deliver (
     const char *sender,
     const char *address,
     const char *subject,
-    zmsg_t     *content,
-    const char *tracking)
+    const char *tracking,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_MAILBOX_DELIVER);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_address       (self, address);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_MAILBOX_DELIVER);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_address (self, address);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the SERVICE_SEND    to the socket in one step
+//  Send the SERVICE_SEND to the socket in one step
 
 int
-mlm_msg_send_service_send  (
+mlm_msg_send_service_send (
     void *output,
     const char *service,
     const char *subject,
-    zmsg_t     *content,
     const char *tracking,
-    uint32_t timeout)
+    uint32_t timeout,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_SEND);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_timeout       (self, timeout);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_SEND);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_timeout (self, timeout);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the SERVICE_OFFER   to the socket in one step
+//  Send the SERVICE_OFFER to the socket in one step
 
 int
 mlm_msg_send_service_offer (
@@ -1478,10 +1478,10 @@ mlm_msg_send_service_offer (
     const char *service,
     const char *pattern)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_OFFER);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_pattern       (self, pattern);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_OFFER);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_pattern (self, pattern);
+    return mlm_msg_send (&self, output);
 }
 
 
@@ -1494,94 +1494,94 @@ mlm_msg_send_service_deliver (
     const char *sender,
     const char *service,
     const char *subject,
-    zmsg_t     *content,
-    const char *tracking)
+    const char *tracking,
+    zmsg_t *content)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_SERVICE_DELIVER);
-    mlm_msg_set_sender        (self, sender);
-    mlm_msg_set_service       (self, service);
-    mlm_msg_set_subject       (self, subject);
-    zmsg_t     *content_copy = zmsg_dup     (content);
-    mlm_msg_set_content       (self, &content_copy);
-    mlm_msg_set_tracking      (self, tracking);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_SERVICE_DELIVER);
+    mlm_msg_set_sender (self, sender);
+    mlm_msg_set_service (self, service);
+    mlm_msg_set_subject (self, subject);
+    mlm_msg_set_tracking (self, tracking);
+    zmsg_t *content_copy = zmsg_dup (content);
+    mlm_msg_set_content (self, &content_copy);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the OK              to the socket in one step
+//  Send the OK to the socket in one step
 
 int
-mlm_msg_send_ok            (
+mlm_msg_send_ok (
     void *output,
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_OK);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_OK);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_send       (&self, output);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the ERROR           to the socket in one step
+//  Send the ERROR to the socket in one step
 
 int
-mlm_msg_send_error         (
+mlm_msg_send_error (
     void *output,
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_ERROR);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_ERROR);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_send       (&self, output);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the CREDIT          to the socket in one step
+//  Send the CREDIT to the socket in one step
 
 int
-mlm_msg_send_credit        (
+mlm_msg_send_credit (
     void *output,
     uint16_t amount)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CREDIT);
-    mlm_msg_set_amount        (self, amount);
-    return mlm_msg_send       (&self, output);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CREDIT);
+    mlm_msg_set_amount (self, amount);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Send the CONFIRM         to the socket in one step
+//  Send the CONFIRM to the socket in one step
 
 int
-mlm_msg_send_confirm       (
+mlm_msg_send_confirm (
     void *output,
     const char *tracking,
     uint16_t status_code,
     const char *status_reason)
 {
-    mlm_msg_t       *self = mlm_msg_new       (MLM_MSG_CONFIRM);
-    mlm_msg_set_tracking      (self, tracking);
-    mlm_msg_set_status_code   (self, status_code);
+    mlm_msg_t *self = mlm_msg_new (MLM_MSG_CONFIRM);
+    mlm_msg_set_tracking (self, tracking);
+    mlm_msg_set_status_code (self, status_code);
     mlm_msg_set_status_reason (self, status_reason);
-    return mlm_msg_send       (&self, output);
+    return mlm_msg_send (&self, output);
 }
 
 
 //  --------------------------------------------------------------------------
-//  Duplicate the mlm_msg       message
+//  Duplicate the mlm_msg message
 
-mlm_msg_t       *
-mlm_msg_dup       (mlm_msg_t       *self)
+mlm_msg_t *
+mlm_msg_dup (mlm_msg_t *self)
 {
     if (!self)
         return NULL;
         
-    mlm_msg_t       *copy = mlm_msg_new       (self->id);
+    mlm_msg_t *copy = mlm_msg_new (self->id);
     if (self->routing_id)
         copy->routing_id = zframe_dup (self->routing_id);
     switch (self->id) {
@@ -1601,48 +1601,48 @@ mlm_msg_dup       (mlm_msg_t       *self)
             break;
 
         case MLM_MSG_STREAM_WRITE:
-            copy->stream  = self->stream?  strdup (self->stream):  NULL;
+            copy->stream = self->stream? strdup (self->stream): NULL;
             break;
 
         case MLM_MSG_STREAM_READ:
-            copy->stream  = self->stream?  strdup (self->stream):  NULL;
+            copy->stream = self->stream? strdup (self->stream): NULL;
             copy->pattern = self->pattern? strdup (self->pattern): NULL;
             break;
 
         case MLM_MSG_STREAM_PUBLISH:
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_STREAM_DELIVER:
-            copy->stream  = self->stream?  strdup (self->stream):  NULL;
-            copy->sender  = self->sender?  strdup (self->sender):  NULL;
+            copy->stream = self->stream? strdup (self->stream): NULL;
+            copy->sender = self->sender? strdup (self->sender): NULL;
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_MAILBOX_SEND:
             copy->address = self->address? strdup (self->address): NULL;
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
             copy->tracking = self->tracking? strdup (self->tracking): NULL;
             copy->timeout = self->timeout;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_MAILBOX_DELIVER:
-            copy->sender  = self->sender?  strdup (self->sender):  NULL;
+            copy->sender = self->sender? strdup (self->sender): NULL;
             copy->address = self->address? strdup (self->address): NULL;
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
             copy->tracking = self->tracking? strdup (self->tracking): NULL;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_SERVICE_SEND:
             copy->service = self->service? strdup (self->service): NULL;
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
             copy->tracking = self->tracking? strdup (self->tracking): NULL;
             copy->timeout = self->timeout;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_SERVICE_OFFER:
@@ -1651,11 +1651,11 @@ mlm_msg_dup       (mlm_msg_t       *self)
             break;
 
         case MLM_MSG_SERVICE_DELIVER:
-            copy->sender  = self->sender?  strdup (self->sender):  NULL;
+            copy->sender = self->sender? strdup (self->sender): NULL;
             copy->service = self->service? strdup (self->service): NULL;
             copy->subject = self->subject? strdup (self->subject): NULL;
-            copy->content = self->content? zmsg_dup     (self->content): NULL;
             copy->tracking = self->tracking? strdup (self->tracking): NULL;
+            copy->content = self->content? zmsg_dup (self->content): NULL;
             break;
 
         case MLM_MSG_OK:
@@ -1669,7 +1669,7 @@ mlm_msg_dup       (mlm_msg_t       *self)
             break;
 
         case MLM_MSG_CREDIT:
-            copy->amount  = self->amount;
+            copy->amount = self->amount;
             break;
 
         case MLM_MSG_CONFIRM:
@@ -1687,7 +1687,7 @@ mlm_msg_dup       (mlm_msg_t       *self)
 //  Print contents of message to stdout
 
 void
-mlm_msg_print       (mlm_msg_t       *self)
+mlm_msg_print (mlm_msg_t *self)
 {
     assert (self);
     switch (self->id) {
@@ -1716,7 +1716,7 @@ mlm_msg_print       (mlm_msg_t       *self)
         case MLM_MSG_STREAM_WRITE:
             zsys_debug ("MLM_MSG_STREAM_WRITE:");
             if (self->stream)
-                zsys_debug ("    stream='%s'",  self->stream);
+                zsys_debug ("    stream='%s'", self->stream);
             else
                 zsys_debug ("    stream=");
             break;
@@ -1724,7 +1724,7 @@ mlm_msg_print       (mlm_msg_t       *self)
         case MLM_MSG_STREAM_READ:
             zsys_debug ("MLM_MSG_STREAM_READ:");
             if (self->stream)
-                zsys_debug ("    stream='%s'",  self->stream);
+                zsys_debug ("    stream='%s'", self->stream);
             else
                 zsys_debug ("    stream=");
             if (self->pattern)
@@ -1749,11 +1749,11 @@ mlm_msg_print       (mlm_msg_t       *self)
         case MLM_MSG_STREAM_DELIVER:
             zsys_debug ("MLM_MSG_STREAM_DELIVER:");
             if (self->stream)
-                zsys_debug ("    stream='%s'",  self->stream);
+                zsys_debug ("    stream='%s'", self->stream);
             else
                 zsys_debug ("    stream=");
             if (self->sender)
-                zsys_debug ("    sender='%s'",  self->sender);
+                zsys_debug ("    sender='%s'", self->sender);
             else
                 zsys_debug ("    sender=");
             if (self->subject)
@@ -1777,22 +1777,22 @@ mlm_msg_print       (mlm_msg_t       *self)
                 zsys_debug ("    subject='%s'", self->subject);
             else
                 zsys_debug ("    subject=");
-            zsys_debug ("    content=");
-            if (self->content)
-                zmsg_print (self->content);
-            else
-                zsys_debug ("(NULL)");
             if (self->tracking)
                 zsys_debug ("    tracking='%s'", self->tracking);
             else
                 zsys_debug ("    tracking=");
             zsys_debug ("    timeout=%ld", (long) self->timeout);
+            zsys_debug ("    content=");
+            if (self->content)
+                zmsg_print (self->content);
+            else
+                zsys_debug ("(NULL)");
             break;
             
         case MLM_MSG_MAILBOX_DELIVER:
             zsys_debug ("MLM_MSG_MAILBOX_DELIVER:");
             if (self->sender)
-                zsys_debug ("    sender='%s'",  self->sender);
+                zsys_debug ("    sender='%s'", self->sender);
             else
                 zsys_debug ("    sender=");
             if (self->address)
@@ -1803,15 +1803,15 @@ mlm_msg_print       (mlm_msg_t       *self)
                 zsys_debug ("    subject='%s'", self->subject);
             else
                 zsys_debug ("    subject=");
+            if (self->tracking)
+                zsys_debug ("    tracking='%s'", self->tracking);
+            else
+                zsys_debug ("    tracking=");
             zsys_debug ("    content=");
             if (self->content)
                 zmsg_print (self->content);
             else
                 zsys_debug ("(NULL)");
-            if (self->tracking)
-                zsys_debug ("    tracking='%s'", self->tracking);
-            else
-                zsys_debug ("    tracking=");
             break;
             
         case MLM_MSG_SERVICE_SEND:
@@ -1824,16 +1824,16 @@ mlm_msg_print       (mlm_msg_t       *self)
                 zsys_debug ("    subject='%s'", self->subject);
             else
                 zsys_debug ("    subject=");
-            zsys_debug ("    content=");
-            if (self->content)
-                zmsg_print (self->content);
-            else
-                zsys_debug ("(NULL)");
             if (self->tracking)
                 zsys_debug ("    tracking='%s'", self->tracking);
             else
                 zsys_debug ("    tracking=");
             zsys_debug ("    timeout=%ld", (long) self->timeout);
+            zsys_debug ("    content=");
+            if (self->content)
+                zmsg_print (self->content);
+            else
+                zsys_debug ("(NULL)");
             break;
             
         case MLM_MSG_SERVICE_OFFER:
@@ -1851,7 +1851,7 @@ mlm_msg_print       (mlm_msg_t       *self)
         case MLM_MSG_SERVICE_DELIVER:
             zsys_debug ("MLM_MSG_SERVICE_DELIVER:");
             if (self->sender)
-                zsys_debug ("    sender='%s'",  self->sender);
+                zsys_debug ("    sender='%s'", self->sender);
             else
                 zsys_debug ("    sender=");
             if (self->service)
@@ -1862,15 +1862,15 @@ mlm_msg_print       (mlm_msg_t       *self)
                 zsys_debug ("    subject='%s'", self->subject);
             else
                 zsys_debug ("    subject=");
+            if (self->tracking)
+                zsys_debug ("    tracking='%s'", self->tracking);
+            else
+                zsys_debug ("    tracking=");
             zsys_debug ("    content=");
             if (self->content)
                 zmsg_print (self->content);
             else
                 zsys_debug ("(NULL)");
-            if (self->tracking)
-                zsys_debug ("    tracking='%s'", self->tracking);
-            else
-                zsys_debug ("    tracking=");
             break;
             
         case MLM_MSG_OK:
@@ -1893,7 +1893,7 @@ mlm_msg_print       (mlm_msg_t       *self)
             
         case MLM_MSG_CREDIT:
             zsys_debug ("MLM_MSG_CREDIT:");
-            zsys_debug ("    amount=%ld",  (long) self->amount);
+            zsys_debug ("    amount=%ld", (long) self->amount);
             break;
             
         case MLM_MSG_CONFIRM:
@@ -1917,14 +1917,14 @@ mlm_msg_print       (mlm_msg_t       *self)
 //  Get/set the message routing_id
 
 zframe_t *
-mlm_msg_routing_id       (mlm_msg_t       *self)
+mlm_msg_routing_id (mlm_msg_t *self)
 {
     assert (self);
     return self->routing_id;
 }
 
 void
-mlm_msg_set_routing_id       (mlm_msg_t       *self, zframe_t *routing_id)
+mlm_msg_set_routing_id (mlm_msg_t *self, zframe_t *routing_id)
 {
     if (self->routing_id)
         zframe_destroy (&self->routing_id);
@@ -1933,17 +1933,17 @@ mlm_msg_set_routing_id       (mlm_msg_t       *self, zframe_t *routing_id)
 
 
 //  --------------------------------------------------------------------------
-//  Get/set the mlm_msg       id
+//  Get/set the mlm_msg id
 
 int
-mlm_msg_id       (mlm_msg_t       *self)
+mlm_msg_id (mlm_msg_t *self)
 {
     assert (self);
     return self->id;
 }
 
 void
-mlm_msg_set_id       (mlm_msg_t       *self, int id)
+mlm_msg_set_id (mlm_msg_t *self, int id)
 {
     self->id = id;
 }
@@ -1952,7 +1952,7 @@ mlm_msg_set_id       (mlm_msg_t       *self, int id)
 //  Return a printable command string
 
 const char *
-mlm_msg_command       (mlm_msg_t       *self)
+mlm_msg_command (mlm_msg_t *self)
 {
     assert (self);
     switch (self->id) {
@@ -2015,14 +2015,14 @@ mlm_msg_command       (mlm_msg_t       *self)
 //  Get/set the address field
 
 const char *
-mlm_msg_address       (mlm_msg_t       *self)
+mlm_msg_address (mlm_msg_t *self)
 {
     assert (self);
     return self->address;
 }
 
 void
-mlm_msg_set_address       (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_address (mlm_msg_t *self, const char *format, ...)
 {
     //  Format address from provided arguments
     assert (self);
@@ -2035,24 +2035,24 @@ mlm_msg_set_address       (mlm_msg_t       *self, const char *format, ...)
 
 
 //  --------------------------------------------------------------------------
-//  Get/set the stream  field
+//  Get/set the stream field
 
 const char *
-mlm_msg_stream        (mlm_msg_t       *self)
+mlm_msg_stream (mlm_msg_t *self)
 {
     assert (self);
     return self->stream;
 }
 
 void
-mlm_msg_set_stream        (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_stream (mlm_msg_t *self, const char *format, ...)
 {
-    //  Format stream  from provided arguments
+    //  Format stream from provided arguments
     assert (self);
     va_list argptr;
     va_start (argptr, format);
     free (self->stream);
-    self->stream  = zsys_vprintf (format, argptr);
+    self->stream = zsys_vprintf (format, argptr);
     va_end (argptr);
 }
 
@@ -2061,14 +2061,14 @@ mlm_msg_set_stream        (mlm_msg_t       *self, const char *format, ...)
 //  Get/set the pattern field
 
 const char *
-mlm_msg_pattern       (mlm_msg_t       *self)
+mlm_msg_pattern (mlm_msg_t *self)
 {
     assert (self);
     return self->pattern;
 }
 
 void
-mlm_msg_set_pattern       (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_pattern (mlm_msg_t *self, const char *format, ...)
 {
     //  Format pattern from provided arguments
     assert (self);
@@ -2084,14 +2084,14 @@ mlm_msg_set_pattern       (mlm_msg_t       *self, const char *format, ...)
 //  Get/set the subject field
 
 const char *
-mlm_msg_subject       (mlm_msg_t       *self)
+mlm_msg_subject (mlm_msg_t *self)
 {
     assert (self);
     return self->subject;
 }
 
 void
-mlm_msg_set_subject       (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_subject (mlm_msg_t *self, const char *format, ...)
 {
     //  Format subject from provided arguments
     assert (self);
@@ -2106,8 +2106,8 @@ mlm_msg_set_subject       (mlm_msg_t       *self, const char *format, ...)
 //  --------------------------------------------------------------------------
 //  Get the content field without transferring ownership
 
-zmsg_t     *
-mlm_msg_content       (mlm_msg_t       *self)
+zmsg_t *
+mlm_msg_content (mlm_msg_t *self)
 {
     assert (self);
     return self->content;
@@ -2115,10 +2115,10 @@ mlm_msg_content       (mlm_msg_t       *self)
 
 //  Get the content field and transfer ownership to caller
 
-zmsg_t     *
-mlm_msg_get_content       (mlm_msg_t       *self)
+zmsg_t *
+mlm_msg_get_content (mlm_msg_t *self)
 {
-    zmsg_t     *content = self->content;
+    zmsg_t *content = self->content;
     self->content = NULL;
     return content;
 }
@@ -2126,35 +2126,35 @@ mlm_msg_get_content       (mlm_msg_t       *self)
 //  Set the content field, transferring ownership from caller
 
 void
-mlm_msg_set_content       (mlm_msg_t       *self, zmsg_t     **msg_p)
+mlm_msg_set_content (mlm_msg_t *self, zmsg_t **msg_p)
 {
     assert (self);
     assert (msg_p);
-    zmsg_destroy     (&self->content);
+    zmsg_destroy (&self->content);
     self->content = *msg_p;
-    *msg_p     = NULL;
+    *msg_p = NULL;
 }
 
 
 //  --------------------------------------------------------------------------
-//  Get/set the sender  field
+//  Get/set the sender field
 
 const char *
-mlm_msg_sender        (mlm_msg_t       *self)
+mlm_msg_sender (mlm_msg_t *self)
 {
     assert (self);
     return self->sender;
 }
 
 void
-mlm_msg_set_sender        (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_sender (mlm_msg_t *self, const char *format, ...)
 {
-    //  Format sender  from provided arguments
+    //  Format sender from provided arguments
     assert (self);
     va_list argptr;
     va_start (argptr, format);
     free (self->sender);
-    self->sender  = zsys_vprintf (format, argptr);
+    self->sender = zsys_vprintf (format, argptr);
     va_end (argptr);
 }
 
@@ -2163,14 +2163,14 @@ mlm_msg_set_sender        (mlm_msg_t       *self, const char *format, ...)
 //  Get/set the tracking field
 
 const char *
-mlm_msg_tracking      (mlm_msg_t       *self)
+mlm_msg_tracking (mlm_msg_t *self)
 {
     assert (self);
     return self->tracking;
 }
 
 void
-mlm_msg_set_tracking      (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_tracking (mlm_msg_t *self, const char *format, ...)
 {
     //  Format tracking from provided arguments
     assert (self);
@@ -2186,14 +2186,14 @@ mlm_msg_set_tracking      (mlm_msg_t       *self, const char *format, ...)
 //  Get/set the timeout field
 
 uint32_t
-mlm_msg_timeout       (mlm_msg_t       *self)
+mlm_msg_timeout (mlm_msg_t *self)
 {
     assert (self);
     return self->timeout;
 }
 
 void
-mlm_msg_set_timeout       (mlm_msg_t       *self, uint32_t timeout)
+mlm_msg_set_timeout (mlm_msg_t *self, uint32_t timeout)
 {
     assert (self);
     self->timeout = timeout;
@@ -2204,14 +2204,14 @@ mlm_msg_set_timeout       (mlm_msg_t       *self, uint32_t timeout)
 //  Get/set the service field
 
 const char *
-mlm_msg_service       (mlm_msg_t       *self)
+mlm_msg_service (mlm_msg_t *self)
 {
     assert (self);
     return self->service;
 }
 
 void
-mlm_msg_set_service       (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_service (mlm_msg_t *self, const char *format, ...)
 {
     //  Format service from provided arguments
     assert (self);
@@ -2227,14 +2227,14 @@ mlm_msg_set_service       (mlm_msg_t       *self, const char *format, ...)
 //  Get/set the status_code field
 
 uint16_t
-mlm_msg_status_code   (mlm_msg_t       *self)
+mlm_msg_status_code (mlm_msg_t *self)
 {
     assert (self);
     return self->status_code;
 }
 
 void
-mlm_msg_set_status_code   (mlm_msg_t       *self, uint16_t status_code)
+mlm_msg_set_status_code (mlm_msg_t *self, uint16_t status_code)
 {
     assert (self);
     self->status_code = status_code;
@@ -2245,14 +2245,14 @@ mlm_msg_set_status_code   (mlm_msg_t       *self, uint16_t status_code)
 //  Get/set the status_reason field
 
 const char *
-mlm_msg_status_reason (mlm_msg_t       *self)
+mlm_msg_status_reason (mlm_msg_t *self)
 {
     assert (self);
     return self->status_reason;
 }
 
 void
-mlm_msg_set_status_reason (mlm_msg_t       *self, const char *format, ...)
+mlm_msg_set_status_reason (mlm_msg_t *self, const char *format, ...)
 {
     //  Format status_reason from provided arguments
     assert (self);
@@ -2265,20 +2265,20 @@ mlm_msg_set_status_reason (mlm_msg_t       *self, const char *format, ...)
 
 
 //  --------------------------------------------------------------------------
-//  Get/set the amount  field
+//  Get/set the amount field
 
 uint16_t
-mlm_msg_amount        (mlm_msg_t       *self)
+mlm_msg_amount (mlm_msg_t *self)
 {
     assert (self);
     return self->amount;
 }
 
 void
-mlm_msg_set_amount        (mlm_msg_t       *self, uint16_t amount)
+mlm_msg_set_amount (mlm_msg_t *self, uint16_t amount)
 {
     assert (self);
-    self->amount  = amount;
+    self->amount = amount;
 }
 
 
@@ -2287,15 +2287,15 @@ mlm_msg_set_amount        (mlm_msg_t       *self, uint16_t amount)
 //  Selftest
 
 int
-mlm_msg_test       (bool verbose)
+mlm_msg_test (bool verbose)
 {
-    printf (" * mlm_msg:       ");
+    printf (" * mlm_msg: ");
 
     //  @selftest
     //  Simple create/destroy test
-    mlm_msg_t       *self = mlm_msg_new       (0);
+    mlm_msg_t *self = mlm_msg_new (0);
     assert (self);
-    mlm_msg_destroy       (&self);
+    mlm_msg_destroy (&self);
 
     //  Create pair of sockets we can send through
     zsock_t *input = zsock_new (ZMQ_ROUTER);
@@ -2308,404 +2308,404 @@ mlm_msg_test       (bool verbose)
 
     //  Encode/send/decode and verify each message type
     int instance;
-    mlm_msg_t       *copy;
-    self = mlm_msg_new       (MLM_MSG_CONNECTION_OPEN);
+    mlm_msg_t *copy;
+    self = mlm_msg_new (MLM_MSG_CONNECTION_OPEN);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_address       (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_address (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_address       (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_address (self), "Life is short but Now lasts for ever"));
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_CONNECTION_PING);
+    self = mlm_msg_new (MLM_MSG_CONNECTION_PING);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_CONNECTION_PONG);
+    self = mlm_msg_new (MLM_MSG_CONNECTION_PONG);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_CONNECTION_CLOSE);
+    self = mlm_msg_new (MLM_MSG_CONNECTION_CLOSE);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_STREAM_WRITE);
+    self = mlm_msg_new (MLM_MSG_STREAM_WRITE);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_stream        (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_stream (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_stream        (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_stream (self), "Life is short but Now lasts for ever"));
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_STREAM_READ);
+    self = mlm_msg_new (MLM_MSG_STREAM_READ);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_stream        (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_pattern       (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_stream (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_pattern (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_stream        (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_pattern       (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_stream (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_pattern (self), "Life is short but Now lasts for ever"));
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_STREAM_PUBLISH);
+    self = mlm_msg_new (MLM_MSG_STREAM_PUBLISH);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
-    zmsg_t *stream_publish_content  = zmsg_new ();
-    mlm_msg_set_content       (self, &stream_publish_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    zmsg_t *stream_publish_content = zmsg_new ();
+    mlm_msg_set_content (self, &stream_publish_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_STREAM_DELIVER);
+    self = mlm_msg_new (MLM_MSG_STREAM_DELIVER);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_stream        (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_sender        (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
-    zmsg_t *stream_deliver_content  = zmsg_new ();
-    mlm_msg_set_content       (self, &stream_deliver_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
+    mlm_msg_set_stream (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_sender (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    zmsg_t *stream_deliver_content = zmsg_new ();
+    mlm_msg_set_content (self, &stream_deliver_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_stream        (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_sender        (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_stream (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_sender (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_MAILBOX_SEND);
+    self = mlm_msg_new (MLM_MSG_MAILBOX_SEND);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_address       (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
-    zmsg_t *mailbox_send_content    = zmsg_new ();
-    mlm_msg_set_content       (self, &mailbox_send_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
-    mlm_msg_set_tracking      (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_timeout       (self, 123);
+    mlm_msg_set_address (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_tracking (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_timeout (self, 123);
+    zmsg_t *mailbox_send_content = zmsg_new ();
+    mlm_msg_set_content (self, &mailbox_send_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_address       (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        assert (streq (mlm_msg_tracking      (self), "Life is short but Now lasts for ever"));
-        assert (mlm_msg_timeout       (self) == 123);
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_address (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_tracking (self), "Life is short but Now lasts for ever"));
+        assert (mlm_msg_timeout (self) == 123);
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_MAILBOX_DELIVER);
+    self = mlm_msg_new (MLM_MSG_MAILBOX_DELIVER);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_sender        (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_address       (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_sender (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_address (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_tracking (self, "Life is short but Now lasts for ever");
     zmsg_t *mailbox_deliver_content = zmsg_new ();
-    mlm_msg_set_content       (self, &mailbox_deliver_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
-    mlm_msg_set_tracking      (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_content (self, &mailbox_deliver_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_sender        (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_address       (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        assert (streq (mlm_msg_tracking      (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_sender (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_address (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_tracking (self), "Life is short but Now lasts for ever"));
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_SERVICE_SEND);
+    self = mlm_msg_new (MLM_MSG_SERVICE_SEND);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_service       (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
-    zmsg_t *service_send_content    = zmsg_new ();
-    mlm_msg_set_content       (self, &service_send_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
-    mlm_msg_set_tracking      (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_timeout       (self, 123);
+    mlm_msg_set_service (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_tracking (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_timeout (self, 123);
+    zmsg_t *service_send_content = zmsg_new ();
+    mlm_msg_set_content (self, &service_send_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_service       (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        assert (streq (mlm_msg_tracking      (self), "Life is short but Now lasts for ever"));
-        assert (mlm_msg_timeout       (self) == 123);
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_service (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_tracking (self), "Life is short but Now lasts for ever"));
+        assert (mlm_msg_timeout (self) == 123);
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_SERVICE_OFFER);
+    self = mlm_msg_new (MLM_MSG_SERVICE_OFFER);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_service       (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_pattern       (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_service (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_pattern (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_service       (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_pattern       (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_service (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_pattern (self), "Life is short but Now lasts for ever"));
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_SERVICE_DELIVER);
+    self = mlm_msg_new (MLM_MSG_SERVICE_DELIVER);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_sender        (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_service       (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_subject       (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_sender (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_service (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_subject (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_tracking (self, "Life is short but Now lasts for ever");
     zmsg_t *service_deliver_content = zmsg_new ();
-    mlm_msg_set_content       (self, &service_deliver_content);
-    zmsg_addstr (mlm_msg_content       (self), "Hello, World");
-    mlm_msg_set_tracking      (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_content (self, &service_deliver_content);
+    zmsg_addstr (mlm_msg_content (self), "Hello, World");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_sender        (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_service       (self), "Life is short but Now lasts for ever"));
-        assert (streq (mlm_msg_subject       (self), "Life is short but Now lasts for ever"));
-        assert (zmsg_size (mlm_msg_content       (self)) == 1);
-        assert (streq (mlm_msg_tracking      (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        assert (streq (mlm_msg_sender (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_service (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_subject (self), "Life is short but Now lasts for ever"));
+        assert (streq (mlm_msg_tracking (self), "Life is short but Now lasts for ever"));
+        assert (zmsg_size (mlm_msg_content (self)) == 1);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_OK);
+    self = mlm_msg_new (MLM_MSG_OK);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_status_code   (self, 123);
+    mlm_msg_set_status_code (self, 123);
     mlm_msg_set_status_reason (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (mlm_msg_status_code   (self) == 123);
+        assert (mlm_msg_status_code (self) == 123);
         assert (streq (mlm_msg_status_reason (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_ERROR);
+    self = mlm_msg_new (MLM_MSG_ERROR);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_status_code   (self, 123);
+    mlm_msg_set_status_code (self, 123);
     mlm_msg_set_status_reason (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (mlm_msg_status_code   (self) == 123);
+        assert (mlm_msg_status_code (self) == 123);
         assert (streq (mlm_msg_status_reason (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_CREDIT);
+    self = mlm_msg_new (MLM_MSG_CREDIT);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_amount        (self, 123);
+    mlm_msg_set_amount (self, 123);
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (mlm_msg_amount        (self) == 123);
-        mlm_msg_destroy       (&self);
+        assert (mlm_msg_amount (self) == 123);
+        mlm_msg_destroy (&self);
     }
-    self = mlm_msg_new       (MLM_MSG_CONFIRM);
+    self = mlm_msg_new (MLM_MSG_CONFIRM);
     
     //  Check that _dup works on empty message
-    copy = mlm_msg_dup       (self);
+    copy = mlm_msg_dup (self);
     assert (copy);
-    mlm_msg_destroy       (&copy);
+    mlm_msg_destroy (&copy);
 
-    mlm_msg_set_tracking      (self, "Life is short but Now lasts for ever");
-    mlm_msg_set_status_code   (self, 123);
+    mlm_msg_set_tracking (self, "Life is short but Now lasts for ever");
+    mlm_msg_set_status_code (self, 123);
     mlm_msg_set_status_reason (self, "Life is short but Now lasts for ever");
     //  Send twice from same object
-    mlm_msg_send_again       (self, output);
-    mlm_msg_send       (&self, output);
+    mlm_msg_send_again (self, output);
+    mlm_msg_send (&self, output);
 
     for (instance = 0; instance < 2; instance++) {
-        self = mlm_msg_recv       (input);
+        self = mlm_msg_recv (input);
         assert (self);
-        assert (mlm_msg_routing_id       (self));
+        assert (mlm_msg_routing_id (self));
         
-        assert (streq (mlm_msg_tracking      (self), "Life is short but Now lasts for ever"));
-        assert (mlm_msg_status_code   (self) == 123);
+        assert (streq (mlm_msg_tracking (self), "Life is short but Now lasts for ever"));
+        assert (mlm_msg_status_code (self) == 123);
         assert (streq (mlm_msg_status_reason (self), "Life is short but Now lasts for ever"));
-        mlm_msg_destroy       (&self);
+        mlm_msg_destroy (&self);
     }
 
     zsock_destroy (&input);

--- a/src/mlm_msg.xml
+++ b/src/mlm_msg.xml
@@ -108,9 +108,9 @@
         discards it and returns a CONFIRM with a TIMEOUT-EXPIRED status.
         <field name = "address" type = "string">Mailbox address</field>
         <field name = "subject" type = "string">Message subject</field>
-        <field name = "content" type = "msg">Message body frames</field>
         <field name = "tracking" type = "string">Message tracking ID</field>
         <field name = "timeout" type = "number" size = "4">Timeout, msecs, or zero</field>
+        <field name = "content" type = "msg">Message body frames</field>
     </message>
 
     <message name = "MAILBOX DELIVER">
@@ -122,8 +122,8 @@
         <field name = "sender" type = "string">Sending client address</field>
         <field name = "address" type = "string">Mailbox address</field>
         <field name = "subject" type = "string">Message subject</field>
-        <field name = "content" type = "msg">Message body frames</field>
         <field name = "tracking" type = "string">Message tracking ID</field>
+        <field name = "content" type = "msg">Message body frames</field>
     </message>
 
     <!-- Service queue operations -->
@@ -136,9 +136,9 @@
         discards it and returns CONFIRM with a TIMEOUT-EXPIRED status.
         <field name = "service" type = "string">Service name</field>
         <field name = "subject" type = "string">Message subject</field>
-        <field name = "content" type = "msg">Message body frames</field>
         <field name = "tracking" type = "string">Message tracking ID</field>
         <field name = "timeout" type = "number" size = "4">Timeout, msecs, or zero</field>
+        <field name = "content" type = "msg">Message body frames</field>
     </message>
 
     <message name = "SERVICE OFFER">
@@ -157,8 +157,8 @@
         <field name = "sender" type = "string">Sending client address</field>
         <field name = "service" type = "string">Service name</field>
         <field name = "subject" type = "string">Message subject</field>
-        <field name = "content" type = "msg">Message body frames</field>
         <field name = "tracking" type = "string">Message tracking ID</field>
+        <field name = "content" type = "msg">Message body frames</field>
     </message>
     
     <!-- These messages are used in all classes -->

--- a/src/mlm_selftest.c
+++ b/src/mlm_selftest.c
@@ -23,6 +23,7 @@ int main (int argc, char *argv [])
 
     printf ("Running self tests...\n");
     mlm_msg_test (verbose);
+    mlm_server_test (verbose);
     printf ("Tests passed OK\n");
     return 0;
 }

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -1,0 +1,435 @@
+/*  =========================================================================
+    mlm_server - Malamute Server
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    This file is part of the Malamute Project.
+                                                                       
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    =========================================================================
+*/
+
+/*
+@header
+    This actor implements the Malamute service. The actor uses the CZMQ socket
+    command interface, rather than a classic C API. You can start as many
+    instances of the Malamute service as you like. Each will run in its own
+    namespace, as virtual hosts. This class is wrapped as a main program via
+    the malamute.c application, and can be wrapped in other languages in the
+    same way as any C API.
+@discuss
+    This is a minimal, incomplete implementation of Malamute. It does however
+    not have any known bugs.
+@end
+*/
+
+#include "../include/malamute.h"
+
+//  ---------------------------------------------------------------------------
+//  Forward declarations for the two main classes we use here
+
+typedef struct _server_t server_t;
+typedef struct _client_t client_t;
+
+//  This structure defines the context for each running server. Store
+//  whatever properties and structures you need for the server.
+
+struct _server_t {
+    //  These properties must always be present in the server_t
+    //  and are set by the generated engine; do not modify them!
+    zsock_t *pipe;              //  Actor pipe back to caller
+    zconfig_t *config;          //  Current loaded configuration
+    
+    //  These properties are specific for this application
+    zlist_t *patterns;          //  List of patterns subscribed to
+
+    //  When we're forwarding a message, we need these
+    const char *sender;         //  Client sender address
+    const char *subject;        //  Message subject
+    zmsg_t *content;            //  Message content
+};
+
+
+//  ---------------------------------------------------------------------------
+//  This structure defines the state for each client connection. It will
+//  be passed to each action in the 'self' argument.
+
+struct _client_t {
+    //  These properties must always be present in the client_t
+    //  and are set by the generated engine; do not modify them!
+    server_t *server;           //  Reference to parent server
+    mlm_msg_t *request;         //  Last received request
+    mlm_msg_t *reply;           //  Reply to send out, if any
+
+    //  These properties are specific for this application
+    char *address;              //  Address of client
+};
+
+//  Include the generated server engine
+#include "mlm_server_engine.inc"
+
+//  This is a simple pattern class
+
+typedef struct {
+    char *pattern;           //  Regular pattern to match on
+    zrex_t *rex;                //  Expression, compiled as a zrex object
+    zlist_t *clients;           //  All clients that asked for this pattern
+} pattern_t;
+
+static void
+s_pattern_destroy (pattern_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        pattern_t *self = *self_p;
+        zrex_destroy (&self->rex);
+        zlist_destroy (&self->clients);
+        free (self->pattern);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+static pattern_t *
+s_pattern_new (const char *pattern, client_t *client)
+{
+    pattern_t *self = (pattern_t *) zmalloc (sizeof (pattern_t));
+    if (self) {
+        self->rex = zrex_new (pattern);
+        if (self->rex)
+            self->pattern = strdup (pattern);
+        if (self->pattern)
+            self->clients = zlist_new ();
+        if (self->clients)
+            zlist_append (self->clients, client);
+        else
+            s_pattern_destroy (&self);
+    }
+    return self;
+}
+
+
+//  Allocate properties and structures for a new server instance.
+//  Return 0 if OK, or -1 if there was an error.
+
+static int
+server_initialize (server_t *self)
+{
+    self->patterns = zlist_new ();
+    zlist_set_destructor (self->patterns, (czmq_destructor *) s_pattern_destroy);
+    return 0;
+}
+
+//  Free properties and structures for a server instance
+
+static void
+server_terminate (server_t *self)
+{
+    zlist_destroy (&self->patterns);
+}
+
+//  Process server API method, return reply message if any
+
+static zmsg_t *
+server_method (server_t *self, const char *method, zmsg_t *msg)
+{
+    return NULL;
+}
+
+
+//  Allocate properties and structures for a new client connection and
+//  optionally engine_set_next_event (). Return 0 if OK, or -1 on error.
+
+static int
+client_initialize (client_t *self)
+{
+    //  Construct properties here
+    return 0;
+}
+
+//  Free properties and structures for a client connection
+
+static void
+client_terminate (client_t *self)
+{
+    pattern_t *pattern = (pattern_t *) zlist_first (self->server->patterns);
+    while (pattern) {
+        zlist_remove (pattern->clients, self);
+        pattern = (pattern_t *) zlist_next (self->server->patterns);
+    }
+    free (self->address);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  register_new_client
+//
+
+static void
+register_new_client (client_t *self)
+{
+    self->address = strdup (mlm_msg_address (self->request));
+    mlm_msg_set_status_code (self->reply, MLM_MSG_SUCCESS);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  deregister_the_client
+//
+
+static void
+deregister_the_client (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_SUCCESS);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  open_stream_writer
+//
+
+static void
+open_stream_writer (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_SUCCESS);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  open_stream_reader
+//
+
+static void
+open_stream_reader (client_t *self)
+{
+    pattern_t *pattern = (pattern_t *) zlist_first (self->server->patterns);
+    while (pattern) {
+        if (streq (pattern->pattern, mlm_msg_pattern (self->request))) {
+            client_t *client = (client_t *) zlist_first (pattern->clients);
+            while (client) {
+                if (client == self)
+                    break;      //  This client is already on the list
+                client = (client_t *) zlist_next (pattern->clients);
+            }
+            //  Add client, if it's new
+            if (!client)
+                zlist_append (pattern->clients, self);
+            break;
+        }
+        pattern = (pattern_t *) zlist_next (self->server->patterns);
+    }
+    //  Add pattern, if it's new
+    if (!pattern)
+        zlist_append (self->server->patterns,
+                      s_pattern_new (mlm_msg_pattern (self->request), self));
+}
+
+
+//  ---------------------------------------------------------------------------
+//  write_message_to_stream
+//
+
+static void
+write_message_to_stream (client_t *self)
+{
+    //  Keep track of the message we're sending out to subscribers
+    self->server->sender = self->address;
+    self->server->subject = mlm_msg_subject (self->request);
+    self->server->content = mlm_msg_content (self->request);
+
+    //  Now find all matching subscribers
+    pattern_t *pattern = (pattern_t *) zlist_first (self->server->patterns);
+    while (pattern) {
+        if (zrex_matches (pattern->rex, mlm_msg_subject (self->request))) {
+            client_t *client = (client_t *) zlist_first (pattern->clients);
+            while (client) {
+                if (client != self)
+                    engine_send_event (client, forward_event);
+                client = (client_t *) zlist_next (pattern->clients);
+            }
+        }
+        pattern = (pattern_t *) zlist_next (self->server->patterns);
+    }
+}
+
+
+//  --------------------------------------------------------------------------
+//  get_content_to_forward
+//
+
+static void
+get_content_to_forward (client_t *self)
+{
+    zmsg_t *content = zmsg_dup (self->server->content);
+    mlm_msg_set_sender  (self->reply, self->server->sender);
+    mlm_msg_set_subject (self->reply, self->server->subject);
+    mlm_msg_set_content (self->reply, &content);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  write_message_to_mailbox
+//
+
+static void
+write_message_to_mailbox (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_NOT_IMPLEMENTED);
+    engine_set_exception (self, exception_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  write_message_to_service
+//
+
+static void
+write_message_to_service (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_NOT_IMPLEMENTED);
+    engine_set_exception (self, exception_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  open_service_worker
+//
+
+static void
+open_service_worker (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_NOT_IMPLEMENTED);
+    engine_set_exception (self, exception_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  have_message_confirmation
+//
+
+static void
+have_message_confirmation (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_NOT_IMPLEMENTED);
+    engine_set_exception (self, exception_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  credit_the_client
+//
+
+static void
+credit_the_client (client_t *self)
+{
+}
+
+
+//  ---------------------------------------------------------------------------
+//  message_not_valid_in_this_state
+//
+
+static void
+message_not_valid_in_this_state (client_t *self)
+{
+    mlm_msg_set_status_code (self->reply, MLM_MSG_COMMAND_INVALID);
+    engine_set_exception (self, exception_event);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Selftest
+
+void
+mlm_server_test (bool verbose)
+{
+    printf (" * mlm_server: ");
+    if (verbose)
+        printf ("\n");
+    
+    //  @selftest
+    zactor_t *server = zactor_new (mlm_server, "mlm_server_test");
+    if (verbose)
+        zstr_send (server, "VERBOSE");
+    zstr_sendx (server, "BIND", "ipc://@/malamute", NULL);
+
+    zsock_t *reader = zsock_new (ZMQ_DEALER);
+    assert (reader);
+    zsock_connect (reader, "ipc://@/malamute");
+    zsock_set_rcvtimeo (reader, 500);
+
+    mlm_msg_t *message;
+
+    //  Server insists that connection starts properly
+    mlm_msg_send_stream_write (reader, "weather");
+    message = mlm_msg_recv (reader);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_ERROR);
+    assert (mlm_msg_status_code (message) == MLM_MSG_COMMAND_INVALID);
+    mlm_msg_destroy (&message);
+
+    //  Now do a stream publish-subscribe test
+    zsock_t *writer = zsock_new (ZMQ_DEALER);
+    assert (writer);
+    zsock_connect (writer, "ipc://@/malamute");
+    zsock_set_rcvtimeo (reader, 500);
+
+    //  Open connections from both reader and writer
+    mlm_msg_send_connection_open (reader, "reader");
+    message = mlm_msg_recv (reader);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_OK);
+    mlm_msg_destroy (&message);
+
+    mlm_msg_send_connection_open (writer, "writer");
+    message = mlm_msg_recv (writer);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_OK);
+    mlm_msg_destroy (&message);
+
+    //  Prepare to write and read a "weather" stream
+    mlm_msg_send_stream_write (writer, "weather");
+    message = mlm_msg_recv (writer);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_OK);
+    mlm_msg_destroy (&message);
+
+    //  Subscriptions are not confirmed
+    mlm_msg_send_stream_read (reader, "weather", "temp.*");
+
+    //  Now send some weather data, with null contents
+    mlm_msg_send_stream_publish (writer, "temp.moscow", NULL);
+    mlm_msg_send_stream_publish (writer, "rain.moscow", NULL);
+    mlm_msg_send_stream_publish (writer, "temp.chicago", NULL);
+    mlm_msg_send_stream_publish (writer, "rain.chicago", NULL);
+    mlm_msg_send_stream_publish (writer, "temp.london", NULL);
+    mlm_msg_send_stream_publish (writer, "rain.london", NULL);
+
+    //  We should receive exactly three deliveries, in order
+    message = mlm_msg_recv (reader);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_STREAM_DELIVER);
+    assert (streq (mlm_msg_subject (message), "temp.moscow"));
+    mlm_msg_destroy (&message);
+
+    message = mlm_msg_recv (reader);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_STREAM_DELIVER);
+    assert (streq (mlm_msg_subject (message), "temp.chicago"));
+    mlm_msg_destroy (&message);
+
+    message = mlm_msg_recv (reader);
+    assert (message);
+    assert (mlm_msg_id (message) == MLM_MSG_STREAM_DELIVER);
+    assert (streq (mlm_msg_subject (message), "temp.london"));
+    mlm_msg_destroy (&message);
+        
+    //  Finished, we can clean up
+    zsock_destroy (&writer);
+    zsock_destroy (&reader);
+    zactor_destroy (&server);
+    
+    //  @end
+    printf ("OK\n");
+}

--- a/src/mlm_server.xml
+++ b/src/mlm_server.xml
@@ -1,0 +1,76 @@
+<class
+    name = "mlm_server"
+    title = "Malamute Server"
+    script = "zproto_server_c"
+    protocol_class = "mlm_msg"
+    package_dir = "../include"
+    project_header = "../include/malamute.h"
+    >
+    This is a server implementation of the malamute Protocol
+    <include filename = "license.xml" />
+
+    <state name = "start" inherit = "external">
+        <event name = "CONNECTION OPEN" next = "connected">
+            <action name = "register new client" />
+            <action name = "send" message = "OK" />
+        </event>
+    </state>
+
+    <state name = "connected" inherit = "external">
+        <event name = "STREAM WRITE">
+            <action name = "open stream writer" />
+            <action name = "send" message = "OK" />
+        </event>
+        <event name = "STREAM READ">
+            <action name = "open stream reader" />
+        </event>
+        <event name = "STREAM PUBLISH">
+            <action name = "write message to stream" />
+        </event>
+        <event name = "forward">
+            <action name = "get content to forward" />
+            <action name = "send" message = "STREAM DELIVER" />
+        </event>
+        <event name = "MAILBOX SEND">
+            <action name = "write message to mailbox" />
+        </event>
+        <event name = "SERVICE SEND">
+            <action name = "write message to service" />
+        </event>
+        <event name = "SERVICE OFFER">
+            <action name = "open service worker" />
+        </event>
+        <event name = "CONFIRM">
+            <action name = "have message confirmation" />
+        </event>
+        <event name = "CREDIT">
+            <action name = "credit the client" />
+        </event>
+        <event name = "CONNECTION PING">
+            <action name = "send" message = "CONNECTION PONG" />
+        </event>
+    </state>
+
+    <state name = "external">
+        <event name = "CONNECTION CLOSE">
+            <action name = "deregister the client" />
+            <action name = "send" message = "OK" />
+            <action name = "terminate" />
+        </event>
+        <!-- All other protocol messages are invalid -->
+        <event name = "*">
+            <action name = "message not valid in this state" />
+            <action name = "send" message = "ERROR" />
+            <action name = "terminate" />
+        </event>
+        <!-- This built-in event hits on a client timeout -->
+        <event name = "expired">
+            <action name = "terminate" />
+        </event>
+        <!-- Client tried to do something we don't allow yet -->
+        <event name = "exception">
+            <action name = "send" message = "ERROR" />
+            <action name = "terminate" />
+        </event>
+   </state>
+</class>

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -1,0 +1,1178 @@
+/*  =========================================================================
+    mlm_server_engine - Malamute Server engine
+
+    ** WARNING *************************************************************
+    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+    your changes at the next build cycle. This is great for temporary printf
+    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+    for commits are:
+
+     * The XML model used for this code generation: mlm_server.xml, or
+     * The code generation script that built this file: zproto_server_c
+    ************************************************************************
+    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    This file is part of the Malamute Project.                         
+                                                                       
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    =========================================================================
+*/
+
+
+//  ---------------------------------------------------------------------------
+//  State machine constants
+
+typedef enum {
+    start_state = 1,
+    connected_state = 2,
+    external_state = 3
+} state_t;
+
+typedef enum {
+    terminate_event = -1,
+    NULL_event = 0,
+    connection_open_event = 1,
+    stream_write_event = 2,
+    stream_read_event = 3,
+    stream_publish_event = 4,
+    forward_event = 5,
+    mailbox_send_event = 6,
+    service_send_event = 7,
+    service_offer_event = 8,
+    confirm_event = 9,
+    credit_event = 10,
+    connection_ping_event = 11,
+    connection_close_event = 12,
+    expired_event = 13,
+    exception_event = 14
+} event_t;
+
+//  Names for state machine logging and error reporting
+static char *
+s_state_name [] = {
+    "(NONE)",
+    "start",
+    "connected",
+    "external"
+};
+
+static char *
+s_event_name [] = {
+    "(NONE)",
+    "CONNECTION_OPEN",
+    "STREAM_WRITE",
+    "STREAM_READ",
+    "STREAM_PUBLISH",
+    "forward",
+    "MAILBOX_SEND",
+    "SERVICE_SEND",
+    "SERVICE_OFFER",
+    "CONFIRM",
+    "CREDIT",
+    "CONNECTION_PING",
+    "CONNECTION_CLOSE",
+    "expired",
+    "exception"
+};
+ 
+
+//  ---------------------------------------------------------------------------
+//  Context for the whole server task. This embeds the application-level
+//  server context at its start (the entire structure, not a reference),
+//  so we can cast a pointer between server_t and s_server_t arbitrarily.
+
+typedef struct {
+    server_t server;            //  Application-level server context
+    zsock_t *pipe;              //  Socket to back to caller API
+    zsock_t *router;            //  Socket to talk to clients
+    int port;                   //  Server port bound to
+    zloop_t *loop;              //  Reactor for server sockets
+    zhash_t *clients;           //  Clients we're connected to
+    zconfig_t *config;          //  Configuration tree
+    uint client_id;             //  Client identifier counter
+    size_t timeout;             //  Default client expiry timeout
+    bool verbose;               //  Verbose logging enabled?
+    char *log_prefix;           //  Default log prefix
+} s_server_t;
+
+
+//  ---------------------------------------------------------------------------
+//  Context for each connected client. This embeds the application-level
+//  client context at its start (the entire structure, not a reference),
+//  so we can cast a pointer between client_t and s_client_t arbitrarily.
+
+typedef struct {
+    client_t client;            //  Application-level client context
+    s_server_t *server;         //  Parent server context
+    char *hashkey;              //  Key into server->clients hash
+    zframe_t *routing_id;       //  Routing_id back to client
+    uint unique_id;             //  Client identifier in server
+    zlist_t *mailbox;           //  Incoming messages
+    state_t state;              //  Current state
+    event_t event;              //  Current event
+    event_t next_event;         //  The next event
+    event_t exception;          //  Exception event, if any
+    int expiry_timer;           //  zloop timer for client timeouts
+    int wakeup_timer;           //  zloop timer for client alarms
+    event_t wakeup_event;       //  Wake up with this event
+    char log_prefix [41];       //  Log prefix string
+} s_client_t;
+
+static int
+    server_initialize (server_t *self);
+static void
+    server_terminate (server_t *self);
+static zmsg_t *
+    server_method (server_t *self, const char *method, zmsg_t *msg);
+static int
+    client_initialize (client_t *self);
+static void
+    client_terminate (client_t *self);
+static void
+    s_client_execute (s_client_t *client, int event);
+static int
+    s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
+static void
+    register_new_client (client_t *self);
+static void
+    open_stream_writer (client_t *self);
+static void
+    open_stream_reader (client_t *self);
+static void
+    write_message_to_stream (client_t *self);
+static void
+    get_content_to_forward (client_t *self);
+static void
+    write_message_to_mailbox (client_t *self);
+static void
+    write_message_to_service (client_t *self);
+static void
+    open_service_worker (client_t *self);
+static void
+    have_message_confirmation (client_t *self);
+static void
+    credit_the_client (client_t *self);
+static void
+    deregister_the_client (client_t *self);
+static void
+    message_not_valid_in_this_state (client_t *self);
+
+//  ---------------------------------------------------------------------------
+//  These methods are an internal API for actions
+
+//  Set the next event, needed in at least one action in an internal
+//  state; otherwise the state machine will wait for a message on the
+//  router socket and treat that as the event.
+
+static void
+engine_set_next_event (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->next_event = event;
+    }
+}
+
+//  Raise an exception with 'event', halting any actions in progress.
+//  Continues execution of actions defined for the exception event.
+
+static void
+engine_set_exception (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->exception = event;
+    }
+}
+
+//  Set wakeup alarm after 'delay' msecs. The next state should
+//  handle the wakeup event. The alarm is cancelled on any other
+//  event.
+
+static void
+engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        if (self->wakeup_timer) {
+            zloop_timer_end (self->server->loop, self->wakeup_timer);
+            self->wakeup_timer = 0;
+        }
+        self->wakeup_timer = zloop_timer (
+            self->server->loop, delay, 1, s_client_handle_wakeup, self);
+        self->wakeup_event = event;
+    }
+}
+
+//  Execute 'event' on specified client. Use this to send events to
+//  other clients. Cancels any wakeup alarm on that client.
+
+static void
+engine_send_event (client_t *client, event_t event)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        s_client_execute (self, event);
+    }
+}
+
+//  Execute 'event' on all clients known to the server. If you pass a
+//  client argument, that client will not receive the broadcast. If you
+//  want to pass any arguments, store them in the server context.
+
+static void
+engine_broadcast_event (server_t *server, client_t *client, event_t event)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        zlist_t *keys = zhash_keys (self->clients);
+        char *key = (char *) zlist_first (keys);
+        while (key) {
+            s_client_t *target = (s_client_t *) zhash_lookup (self->clients, key);
+            if (target != (s_client_t *) client)
+                s_client_execute (target, event);
+            key = (char *) zlist_next (keys);
+        }
+        zlist_destroy (&keys);
+    }
+}
+
+//  Poll socket for activity, invoke handler on any received message.
+//  Handler must be a CZMQ zloop_fn function; receives server as arg.
+
+static void
+engine_handle_socket (server_t *server, zsock_t *socket, zloop_reader_fn handler)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        if (handler != NULL) {
+            int rc = zloop_reader (self->loop, socket, handler, self);
+            assert (rc == 0);
+            zloop_reader_set_tolerant (self->loop, socket);
+        }
+        else
+            zloop_reader_end (self->loop, socket);
+    }
+}
+
+//  Register monitor function that will be called at regular intervals
+//  by the server engine
+
+static void
+engine_set_monitor (server_t *server, size_t interval, zloop_timer_fn monitor)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        int rc = zloop_timer (self->loop, interval, 0, monitor, self);
+        assert (rc >= 0);
+    }
+}
+
+//  Set log file prefix; this string will be added to log data, to make
+//  log data more searchable. The string is truncated to ~20 chars.
+
+static void
+engine_set_log_prefix (client_t *client, const char *string)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+            "%6d:%-33s", self->unique_id, string);
+    }
+}
+
+//  Set a configuration value in the server's configuration tree. The
+//  properties this engine uses are: server/verbose, server/timeout, and
+//  server/background. You can also configure other abitrary properties.
+
+static void
+engine_configure (server_t *server, const char *path, const char *value)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        zconfig_put (self->config, path, value);
+    }
+}
+
+//  Return true if server is running in verbose mode, else return false.
+
+static bool
+engine_verbose (server_t *server)
+{
+    if (server) {
+        s_server_t *self = (s_server_t *) server;
+        return self->verbose;
+    }
+    return false;
+}
+
+//  Pedantic compilers don't like unused functions, so we call the whole
+//  API, passing null references. It's nasty and horrid and sufficient.
+
+static void
+s_satisfy_pedantic_compilers (void)
+{
+    engine_set_next_event (NULL, NULL_event);
+    engine_set_exception (NULL, NULL_event);
+    engine_set_wakeup_event (NULL, 0, NULL_event);
+    engine_send_event (NULL, NULL_event);
+    engine_broadcast_event (NULL, NULL, NULL_event);
+    engine_handle_socket (NULL, 0, NULL);
+    engine_set_monitor (NULL, 0, NULL);
+    engine_set_log_prefix (NULL, NULL);
+    engine_configure (NULL, NULL, NULL);
+    engine_verbose (NULL);
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Generic methods on protocol messages
+//  TODO: replace with lookup table, since ID is one byte
+
+static event_t
+s_protocol_event (mlm_msg_t *request)
+{
+    assert (request);
+    switch (mlm_msg_id (request)) {
+        case MLM_MSG_CONNECTION_OPEN:
+            return connection_open_event;
+            break;
+        case MLM_MSG_CONNECTION_PING:
+            return connection_ping_event;
+            break;
+        case MLM_MSG_CONNECTION_CLOSE:
+            return connection_close_event;
+            break;
+        case MLM_MSG_STREAM_WRITE:
+            return stream_write_event;
+            break;
+        case MLM_MSG_STREAM_READ:
+            return stream_read_event;
+            break;
+        case MLM_MSG_STREAM_PUBLISH:
+            return stream_publish_event;
+            break;
+        case MLM_MSG_MAILBOX_SEND:
+            return mailbox_send_event;
+            break;
+        case MLM_MSG_SERVICE_SEND:
+            return service_send_event;
+            break;
+        case MLM_MSG_SERVICE_OFFER:
+            return service_offer_event;
+            break;
+        case MLM_MSG_CREDIT:
+            return credit_event;
+            break;
+        case MLM_MSG_CONFIRM:
+            return confirm_event;
+            break;
+        default:
+            //  Invalid mlm_msg_t
+            return terminate_event;
+    }
+}
+
+
+//  ---------------------------------------------------------------------------
+//  Client methods
+
+static s_client_t *
+s_client_new (s_server_t *server, zframe_t *routing_id)
+{
+    s_client_t *self = (s_client_t *) zmalloc (sizeof (s_client_t));
+    assert (self);
+    assert ((s_client_t *) &self->client == self);
+    
+    self->server = server;
+    self->hashkey = zframe_strhex (routing_id);
+    self->routing_id = zframe_dup (routing_id);
+    self->mailbox = zlist_new ();
+    self->unique_id = server->client_id++;
+    engine_set_log_prefix (&self->client, server->log_prefix);
+
+    self->client.server = (server_t *) server;
+    self->client.reply = mlm_msg_new (0);
+    mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+
+    //  Give application chance to initialize and set next event
+    self->state = start_state;
+    self->event = NULL_event;
+    client_initialize (&self->client);
+    return self;
+}
+
+static void
+s_client_destroy (s_client_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        s_client_t *self = *self_p;
+        mlm_msg_destroy (&self->client.request);
+        mlm_msg_destroy (&self->client.reply);
+        
+        if (self->wakeup_timer)
+            zloop_timer_end (self->server->loop, self->wakeup_timer);
+        if (self->expiry_timer)
+            zloop_timer_end (self->server->loop, self->expiry_timer);
+            
+        //  Empty and destroy mailbox
+        mlm_msg_t *request = (mlm_msg_t *) zlist_first (self->mailbox);
+        while (request) {
+            mlm_msg_destroy (&request);
+            request = (mlm_msg_t *) zlist_next (self->mailbox);
+        }
+        zlist_destroy (&self->mailbox);
+        zframe_destroy (&self->routing_id);
+        client_terminate (&self->client);
+        free (self->hashkey);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  Callback when we remove client from 'clients' hash table
+static void
+s_client_free (void *argument)
+{
+    s_client_t *client = (s_client_t *) argument;
+    s_client_destroy (&client);
+}
+
+//  Do we accept a request off the mailbox? If so, return the event for
+//  the message, and load the message into the current client request.
+//  If not, return NULL_event;
+
+static event_t
+s_client_filter_mailbox (s_client_t *self)
+{
+    assert (self);
+    
+    mlm_msg_t *request = (mlm_msg_t *) zlist_first (self->mailbox);
+    while (request) {
+        //  Check whether current state can process event
+        //  This should be changed to a pre-built lookup table
+        event_t event = s_protocol_event (request);
+        bool event_is_valid;
+        if (self->state == start_state)
+            event_is_valid = true;
+        else
+        if (self->state == connected_state)
+            event_is_valid = true;
+        else
+        if (self->state == external_state)
+            event_is_valid = true;
+        else
+            event_is_valid = false;
+            
+        if (event_is_valid) {
+            zlist_remove (self->mailbox, request);
+            mlm_msg_destroy (&self->client.request);
+            self->client.request = request;
+            return event;
+        }
+        request = (mlm_msg_t *) zlist_next (self->mailbox);
+    }
+    return NULL_event;
+}
+
+
+//  Execute state machine as long as we have events
+
+static void
+s_client_execute (s_client_t *self, event_t event)
+{
+    self->next_event = event;
+    //  Cancel wakeup timer, if any was pending
+    if (self->wakeup_timer) {
+        zloop_timer_end (self->server->loop, self->wakeup_timer);
+        self->wakeup_timer = 0;
+    }
+    while (self->next_event != NULL_event) {
+        self->event = self->next_event;
+        self->next_event = NULL_event;
+        self->exception = NULL_event;
+        if (self->server->verbose) {
+            zsys_debug ("%s: %s:",
+                self->log_prefix, s_state_name [self->state]);
+            zsys_debug ("%s:     %s",
+                self->log_prefix, s_event_name [self->event]);
+        }
+        switch (self->state) {
+            case start_state:
+                if (self->event == connection_open_event) {
+                    if (!self->exception) {
+                        //  register new client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ register new client", self->log_prefix);
+                        register_new_client (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OK",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_OK);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception)
+                        self->state = connected_state;
+                }
+                else
+                if (self->event == connection_close_event) {
+                    if (!self->exception) {
+                        //  deregister the client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the client", self->log_prefix);
+                        deregister_the_client (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OK",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_OK);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                break;
+
+            case connected_state:
+                if (self->event == stream_write_event) {
+                    if (!self->exception) {
+                        //  open stream writer
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ open stream writer", self->log_prefix);
+                        open_stream_writer (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OK",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_OK);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                }
+                else
+                if (self->event == stream_read_event) {
+                    if (!self->exception) {
+                        //  open stream reader
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ open stream reader", self->log_prefix);
+                        open_stream_reader (&self->client);
+                    }
+                }
+                else
+                if (self->event == stream_publish_event) {
+                    if (!self->exception) {
+                        //  write message to stream
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ write message to stream", self->log_prefix);
+                        write_message_to_stream (&self->client);
+                    }
+                }
+                else
+                if (self->event == forward_event) {
+                    if (!self->exception) {
+                        //  get content to forward
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ get content to forward", self->log_prefix);
+                        get_content_to_forward (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send STREAM_DELIVER
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send STREAM_DELIVER",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_STREAM_DELIVER);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                }
+                else
+                if (self->event == mailbox_send_event) {
+                    if (!self->exception) {
+                        //  write message to mailbox
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ write message to mailbox", self->log_prefix);
+                        write_message_to_mailbox (&self->client);
+                    }
+                }
+                else
+                if (self->event == service_send_event) {
+                    if (!self->exception) {
+                        //  write message to service
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ write message to service", self->log_prefix);
+                        write_message_to_service (&self->client);
+                    }
+                }
+                else
+                if (self->event == service_offer_event) {
+                    if (!self->exception) {
+                        //  open service worker
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ open service worker", self->log_prefix);
+                        open_service_worker (&self->client);
+                    }
+                }
+                else
+                if (self->event == confirm_event) {
+                    if (!self->exception) {
+                        //  have message confirmation
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ have message confirmation", self->log_prefix);
+                        have_message_confirmation (&self->client);
+                    }
+                }
+                else
+                if (self->event == credit_event) {
+                    if (!self->exception) {
+                        //  credit the client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ credit the client", self->log_prefix);
+                        credit_the_client (&self->client);
+                    }
+                }
+                else
+                if (self->event == connection_ping_event) {
+                    if (!self->exception) {
+                        //  send CONNECTION_PONG
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send CONNECTION_PONG",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_CONNECTION_PONG);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                }
+                else
+                if (self->event == connection_close_event) {
+                    if (!self->exception) {
+                        //  deregister the client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the client", self->log_prefix);
+                        deregister_the_client (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OK",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_OK);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                break;
+
+            case external_state:
+                if (self->event == connection_close_event) {
+                    if (!self->exception) {
+                        //  deregister the client
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ deregister the client", self->log_prefix);
+                        deregister_the_client (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send OK
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send OK",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_OK);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == expired_event) {
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else
+                if (self->event == exception_event) {
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                else {
+                    //  Handle unexpected protocol events
+                    if (!self->exception) {
+                        //  message not valid in this state
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ message not valid in this state", self->log_prefix);
+                        message_not_valid_in_this_state (&self->client);
+                    }
+                    if (!self->exception) {
+                        //  send ERROR
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ send ERROR",
+                                self->log_prefix);
+                        mlm_msg_set_id (self->client.reply, MLM_MSG_ERROR);
+                        mlm_msg_send (&self->client.reply, self->server->router);
+                        self->client.reply = mlm_msg_new (0);
+                        mlm_msg_set_routing_id (self->client.reply, self->routing_id);
+                    }
+                    if (!self->exception) {
+                        //  terminate
+                        if (self->server->verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->next_event = terminate_event;
+                    }
+                }
+                break;
+        }
+        //  If we had an exception event, interrupt normal programming
+        if (self->exception) {
+            if (self->server->verbose)
+                zsys_debug ("%s:         ! %s",
+                    self->log_prefix, s_event_name [self->exception]);
+
+            self->next_event = self->exception;
+        }
+        if (self->next_event == terminate_event) {
+            //  Automatically calls s_client_destroy
+            zhash_delete (self->server->clients, self->hashkey);
+            break;
+        }
+        else {
+            if (self->server->verbose)
+                zsys_debug ("%s:         > %s",
+                    self->log_prefix, s_state_name [self->state]);
+
+            if (self->next_event == NULL_event)
+                //  Get next valid message from mailbox, if any
+                self->next_event = s_client_filter_mailbox (self);
+        }
+    }
+}
+
+//  zloop callback when client inactivity timer expires
+
+static int
+s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, expired_event);
+    return 0;
+}
+
+//  zloop callback when client wakeup timer expires
+
+static int
+s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, self->wakeup_event);
+    return 0;
+}
+
+
+//  Server methods
+
+static void
+s_server_config_self (s_server_t *self)
+{
+    //  Built-in server configuration options
+    //  
+    //  If we didn't already set verbose, check if the config tree wants it
+    if (!self->verbose
+    && atoi (zconfig_resolve (self->config, "server/verbose", "0")))
+        self->verbose = true;
+        
+    //  Default client timeout is 60 seconds
+    self->timeout = atoi (
+        zconfig_resolve (self->config, "server/timeout", "60000"));
+
+    //  Do we want to run server in the background?
+    int background = atoi (
+        zconfig_resolve (self->config, "server/background", "0"));
+    if (!background)
+        zsys_set_logstream (stdout);
+}
+
+static s_server_t *
+s_server_new (zsock_t *pipe)
+{
+    s_server_t *self = (s_server_t *) zmalloc (sizeof (s_server_t));
+    assert (self);
+    assert ((s_server_t *) &self->server == self);
+
+    self->pipe = pipe;
+    self->router = zsock_new (ZMQ_ROUTER);
+    //  By default the socket will discard outgoing messages above the
+    //  HWM of 1,000. This isn't helpful for high-volume streaming. We
+    //  will use a unbounded queue here. If applications need to guard
+    //  against queue overflow, they should use a credit-based flow
+    //  control scheme.
+    zsock_set_unbounded (self->router);
+    self->clients = zhash_new ();
+    self->config = zconfig_new ("root", NULL);
+    self->loop = zloop_new ();
+    srandom ((unsigned int) zclock_time ());
+    self->client_id = randof (1000);
+    s_server_config_self (self);
+
+    //  Initialize application server context
+    self->server.pipe = self->pipe;
+    self->server.config = self->config;
+    server_initialize (&self->server);
+
+    s_satisfy_pedantic_compilers ();
+    return self;
+}
+
+static void
+s_server_destroy (s_server_t **self_p)
+{
+    assert (self_p);
+    if (*self_p) {
+        s_server_t *self = *self_p;
+        //  Destroy clients before destroying the server
+        zhash_destroy (&self->clients);
+        server_terminate (&self->server);
+        zsock_destroy (&self->router);
+        zconfig_destroy (&self->config);
+        zloop_destroy (&self->loop);
+        free (self);
+        *self_p = NULL;
+    }
+}
+
+//  Apply configuration tree:
+//   * apply server configuration
+//   * print any echo items in top-level sections
+//   * apply sections that match methods
+
+static void
+s_server_apply_config (s_server_t *self)
+{
+    //  Apply echo commands and class methods
+    zconfig_t *section = zconfig_locate (self->config, "mlm_server");
+    if (section)
+        section = zconfig_child (section);
+
+    while (section) {
+        if (streq (zconfig_name (section), "echo"))
+            zsys_notice ("%s", zconfig_value (section));
+        else
+        if (streq (zconfig_name (section), "bind")) {
+            char *endpoint = zconfig_resolve (section, "endpoint", "?");
+            if (zsock_bind (self->router, "%s", endpoint) == -1)
+                zsys_warning ("could not bind to %s (%s)", endpoint, zmq_strerror (zmq_errno ()));
+        }
+        section = zconfig_next (section);
+    }
+    s_server_config_self (self);
+}
+
+//  Process message from pipe
+
+static int
+s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    zmsg_t *msg = zmsg_recv (self->pipe);
+    if (!msg)
+        return -1;              //  Interrupted; exit zloop
+    char *method = zmsg_popstr (msg);
+    if (self->verbose)
+        zsys_debug ("%s:     API command=%s", self->log_prefix, method);
+    
+    if (streq (method, "VERBOSE"))
+        self->verbose = true;
+    else
+    if (streq (method, "$TERM")) {
+        //  Shutdown the engine
+        free (method);
+        zmsg_destroy (&msg);
+        return -1;
+    }
+    else
+    if (streq (method, "BIND")) {
+        //  Bind to a specified endpoint, which may use an ephemeral port
+        char *endpoint = zmsg_popstr (msg);
+        self->port = zsock_bind (self->router, "%s", endpoint);
+        if (self->port == -1)
+            zsys_warning ("could not bind to %s", endpoint);
+        free (endpoint);
+    }
+    else
+    if (streq (method, "PORT")) {
+        //  Return PORT + port number from the last bind, if any
+        zstr_sendm (self->pipe, "PORT");
+        zstr_sendf (self->pipe, "%d", self->port);
+    }
+    else
+    if (streq (method, "CONFIGURE")) {
+        char *config_file = zmsg_popstr (msg);
+        zconfig_destroy (&self->config);
+        self->config = zconfig_load (config_file);
+        if (self->config) {
+            s_server_apply_config (self);
+            self->server.config = self->config;
+        }
+        else {
+            zsys_warning ("cannot load config file '%s'\n", config_file);
+            self->config = zconfig_new ("root", NULL);
+        }
+        free (config_file);
+    }
+    else
+    if (streq (method, "SET")) {
+        char *path = zmsg_popstr (msg);
+        char *value = zmsg_popstr (msg);
+        zconfig_put (self->config, path, value);
+        if (streq (path, "server/animate")) {
+            zsys_warning ("'%s' is deprecated, use VERBOSE command instead", path);
+            self->verbose = atoi (value);
+        }
+        s_server_config_self (self);
+        free (path);
+        free (value);
+    }
+    else {
+        //  Execute custom method
+        zmsg_t *reply = server_method (&self->server, method, msg);
+        //  If reply isn't null, send it to caller
+        zmsg_send (&reply, self->pipe);
+    }
+    free (method);
+    zmsg_destroy (&msg);
+    return 0;
+}
+
+//  Handle a message (a protocol request) from the client
+
+static int
+s_server_client_message (zloop_t *loop, zsock_t *reader, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    mlm_msg_t *msg = mlm_msg_recv (self->router);
+    if (!msg)
+        return -1;              //  Interrupted; exit zloop
+
+    char *hashkey = zframe_strhex (mlm_msg_routing_id (msg));
+    s_client_t *client = (s_client_t *) zhash_lookup (self->clients, hashkey);
+    if (client == NULL) {
+        client = s_client_new (self, mlm_msg_routing_id (msg));
+        zhash_insert (self->clients, hashkey, client);
+        zhash_freefn (self->clients, hashkey, s_client_free);
+    }
+    free (hashkey);
+
+    //  Any input from client counts as activity
+    if (client->expiry_timer) {
+        zloop_timer_end (self->loop, client->expiry_timer);
+        client->expiry_timer = 0;
+    }
+    //  Reset expiry timer if timeout is not zero
+    if (self->timeout)
+        client->expiry_timer = zloop_timer (
+            self->loop, self->timeout, 1, s_client_handle_timeout, client);
+        
+    //  Queue request and possibly pass it to client state machine
+    zlist_append (client->mailbox, msg);
+    event_t event = s_client_filter_mailbox (client);
+    if (event != NULL_event)
+        s_client_execute (client, event);
+        
+    return 0;
+}
+
+//  Watch server config file and reload if changed
+
+static int
+s_watch_server_config (zloop_t *loop, int timer_id, void *argument)
+{
+    s_server_t *self = (s_server_t *) argument;
+    if (zconfig_has_changed (self->config)
+    &&  zconfig_reload (&self->config) == 0) {
+        s_server_config_self (self);
+        self->server.config = self->config;
+        zsys_notice ("reloaded configuration from %s",
+            zconfig_filename (self->config));
+    }
+    return 0;
+}
+
+
+//  ---------------------------------------------------------------------------
+//  This is the server actor, which polls its two sockets and processes
+//  incoming messages
+
+void
+mlm_server (zsock_t *pipe, void *args)
+{
+    //  Initialize
+    s_server_t *self = s_server_new (pipe);
+    assert (self);
+    zsock_signal (pipe, 0);
+    //  Actor argument may be a string used for logging
+    self->log_prefix = args? (char *) args: "";
+
+    //  Set-up server monitor to watch for config file changes
+    engine_set_monitor ((server_t *) self, 1000, s_watch_server_config);
+    //  Set up handler for the two main sockets the server uses
+    engine_handle_socket ((server_t *) self, self->pipe, s_server_api_message);
+    engine_handle_socket ((server_t *) self, self->router, s_server_client_message);
+
+    //  Run reactor until there's a termination signal
+    zloop_start (self->loop);
+
+    //  Reactor has ended
+    s_server_destroy (&self);
+}

--- a/src/selftest
+++ b/src/selftest
@@ -1,0 +1,15 @@
+#! /bin/bash
+#
+#   Run selftests and check memory
+
+MAIN=mlm_selftest
+VG="valgrind --tool=memcheck --leak-check=full --show-reachable=yes --suppressions=valgrind.supp"
+
+make code
+gcc -g -o $MAIN \
+    $MAIN.c \
+    mlm_msg.c mlm_server.c \
+    -lczmq -lzmq -lzyre -luuid -lsodium
+test $? -ne 0 && exit
+$VG ./$MAIN
+rm -f vgcore.*


### PR DESCRIPTION
Solution: faster than the eye can see, Hintjens rips off the server core
from ZCCP and thunks that into the Malamute Protocol. The audience doesn't
quite follow, which is the secret to every magic trick. In about an hour
and a quarter, we get from protocol wireframe to a working stream server
that can do transient pubsub using regular expression matching.

If you want to look at how it's done, the key is mlm_server.xml, which is
the state machine model for the server. This defines the logic for each
message, according to the current client connection state.

If this is easy, it's because we're standing on the rather bruised and yet
surprisingly solid shoulders of zproto and its antecedants.
