### PR TITLE
Problem: mlm_selftest.c fails build

### DIFF
--- a/src/mlm_selftest.c
+++ b/src/mlm_selftest.c
@@ -12,6 +12,7 @@
 */
 
 #include "mlm_classes.h"
+#include "labs/zbits.h"
 
 int main (int argc, char *argv [])
 {


### PR DESCRIPTION
Solution: Added missing include of labs/zbits.h
