### PR TITLE
Problem: naive server design is too slow

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,12 +19,13 @@ libmlm_la_SOURCES = \
 AM_CFLAGS = -g
 AM_CPPFLAGS = -I$(top_srcdir)/include
 bin_PROGRAMS = malamute mshell
-noinst_PROGRAMS = mlm_selftest tutorial
+noinst_PROGRAMS = mlm_selftest tutorial perftest
 
 malamute_LDADD = libmlm.la
 mshell_LDADD = libmlm.la
 mlm_selftest_LDADD = libmlm.la
 tutorial_LDADD = libmlm.la
+perftest_LDADD = libmlm.la
 
 libmlm_la_LDFLAGS = -version-info @LTVER@
 

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -754,59 +754,68 @@ static int
 s_client_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
 {
     s_client_t *self = (s_client_t *) argument;
-    char *method = zstr_recv (self->pipe);
-    if (!method)
-        return -1;              //  Interrupted; exit zloop
-    if (self->verbose)
-        zsys_debug ("mlm_client:        API command=%s", method);
-    
-    if (streq (method, "VERBOSE"))
-        self->verbose = true;
-    else
-    if (streq (method, "$TERM")) {
-        //  Shutdown the engine
+    while (zsock_events (self->pipe) & ZMQ_POLLIN) {
+        char *method = zstr_recv (self->pipe);
+        if (!method)
+            return -1;                  //  Interrupted; exit zloop
+        if (self->verbose)
+            zsys_debug ("mlm_client:        API command=%s", method);
+
+        if (streq (method, "VERBOSE"))
+            self->verbose = true;       //  Start verbose logging
+        else
+        if (streq (method, "$TERM"))
+            self->terminated = true;    //  Shutdown the engine
+        else
+        if (streq (method, "CONSTRUCTOR")) {
+            zstr_free (&self->args.endpoint);
+            zsock_recv (self->pipe, "si", &self->args.endpoint, &self->args.timeout);
+            s_client_execute (self, constructor_event);
+            if (self->terminated)
+                return -1;
+        }
+        else
+        if (streq (method, "DESTRUCTOR")) {
+            s_client_execute (self, destructor_event);
+            if (self->terminated)
+                return -1;
+        }
+        else
+        if (streq (method, "PRODUCE")) {
+            zstr_free (&self->args.stream);
+            zsock_recv (self->pipe, "s", &self->args.stream);
+            s_client_execute (self, produce_event);
+            if (self->terminated)
+                return -1;
+        }
+        else
+        if (streq (method, "CONSUME")) {
+            zstr_free (&self->args.stream);
+            zstr_free (&self->args.pattern);
+            zsock_recv (self->pipe, "ss", &self->args.stream, &self->args.pattern);
+            s_client_execute (self, consume_event);
+            if (self->terminated)
+                return -1;
+        }
+        else
+        if (streq (method, "SEND")) {
+            zstr_free (&self->args.subject);
+            zstr_free (&self->args.content);
+            zsock_recv (self->pipe, "ss", &self->args.subject, &self->args.content);
+            s_client_execute (self, send_event);
+            if (self->terminated)
+                return -1;
+        }
+        //  Cleanup pipe if any argument frames are still waiting to be eaten
+        if (zsock_rcvmore (self->pipe)) {
+            zsys_error ("mlm_client: trailing API command frames (%s)", method);
+            zmsg_t *more = zmsg_recv (self->pipe);
+            zmsg_print (more);
+            zmsg_destroy (&more);
+        }
         zstr_free (&method);
-        self->terminated = true;
     }
-    else
-    if (streq (method, "CONSTRUCTOR")) {
-        zstr_free (&self->args.endpoint);
-        zsock_recv (self->pipe, "si", &self->args.endpoint, &self->args.timeout);
-        s_client_execute (self, constructor_event);
-    }
-    else
-    if (streq (method, "DESTRUCTOR")) {
-        s_client_execute (self, destructor_event);
-    }
-    else
-    if (streq (method, "PRODUCE")) {
-        zstr_free (&self->args.stream);
-        zsock_recv (self->pipe, "s", &self->args.stream);
-        s_client_execute (self, produce_event);
-    }
-    else
-    if (streq (method, "CONSUME")) {
-        zstr_free (&self->args.stream);
-        zstr_free (&self->args.pattern);
-        zsock_recv (self->pipe, "ss", &self->args.stream, &self->args.pattern);
-        s_client_execute (self, consume_event);
-    }
-    else
-    if (streq (method, "SEND")) {
-        zstr_free (&self->args.subject);
-        zstr_free (&self->args.content);
-        zsock_recv (self->pipe, "ss", &self->args.subject, &self->args.content);
-        s_client_execute (self, send_event);
-    }
-    //  Cleanup pipe if any argument frames are still waiting to be eaten
-    if (zsock_rcvmore (self->pipe)) {
-        zsys_error ("mlm_client: trailing API command frames (%s)", method);
-        zmsg_t *more = zmsg_recv (self->pipe);
-        zmsg_print (more);
-        zmsg_destroy (&more);
-    }
-    zstr_free (&method);
-    return self->terminated? -1: 0;
+    return 0;
 }
 
 //  Handle a message (a protocol reply) from the server
@@ -815,24 +824,31 @@ static int
 s_client_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
 {
     s_client_t *self = (s_client_t *) argument;
-    mlm_msg_t *msgin = mlm_msg_recv (self->dealer);
-    if (!msgin)
-        return -1;              //  Interrupted; exit zloop
 
-    mlm_msg_destroy (&self->client.msgin);
-    self->client.msgin = msgin;
+    //  We will process as many messages as we can, to reduce the overhead
+    //  of polling and the reactor:
+    while (zsock_events (self->dealer) & ZMQ_POLLIN) {
+        mlm_msg_t *msgin = mlm_msg_recv (self->dealer);
+        if (!msgin)
+            return -1;              //  Interrupted; exit zloop
 
-    //  Any input from client counts as activity
-    if (self->expiry_timer) {
-        zloop_timer_end (self->loop, self->expiry_timer);
-        self->expiry_timer = 0;
+        mlm_msg_destroy (&self->client.msgin);
+        self->client.msgin = msgin;
+
+        //  Any input from client counts as activity
+        if (self->expiry_timer) {
+            zloop_timer_end (self->loop, self->expiry_timer);
+            self->expiry_timer = 0;
+        }
+        //  Reset expiry timer if timeout is not zero
+        if (self->timeout)
+            self->expiry_timer = zloop_timer (
+                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+        s_client_execute (self, s_protocol_event (self, msgin));
+        if (self->terminated)
+            return -1;
     }
-    //  Reset expiry timer if timeout is not zero
-    if (self->timeout)
-        self->expiry_timer = zloop_timer (
-            self->loop, self->timeout, 1, s_client_handle_timeout, self);
-    s_client_execute (self, s_protocol_event (self, msgin));
-    return self->terminated? -1: 0;
+    return 0;
 }
 
 

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -81,7 +81,6 @@ static int
 s_forward_traffic (zloop_t *loop, zsock_t *reader, void *argument)
 {
     server_t *self = (server_t *) argument;
-
     void *client;
     zstr_free (&self->sender);
     zstr_free (&self->subject);

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -1032,114 +1032,119 @@ s_server_apply_config (s_server_t *self)
 //  Process message from pipe
 
 static int
-s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
+s_server_handle_pipe (zloop_t *loop, zsock_t *reader, void *argument)
 {
     s_server_t *self = (s_server_t *) argument;
-    zmsg_t *msg = zmsg_recv (self->pipe);
-    if (!msg)
-        return -1;              //  Interrupted; exit zloop
-    char *method = zmsg_popstr (msg);
-    if (self->verbose)
-        zsys_debug ("%s:     API command=%s", self->log_prefix, method);
-    
-    if (streq (method, "VERBOSE"))
-        self->verbose = true;
-    else
-    if (streq (method, "$TERM")) {
-        //  Shutdown the engine
-        free (method);
-        zmsg_destroy (&msg);
-        return -1;
-    }
-    else
-    if (streq (method, "BIND")) {
-        //  Bind to a specified endpoint, which may use an ephemeral port
-        char *endpoint = zmsg_popstr (msg);
-        self->port = zsock_bind (self->router, "%s", endpoint);
-        if (self->port == -1)
-            zsys_warning ("could not bind to %s", endpoint);
-        free (endpoint);
-    }
-    else
-    if (streq (method, "PORT")) {
-        //  Return PORT + port number from the last bind, if any
-        zstr_sendm (self->pipe, "PORT");
-        zstr_sendf (self->pipe, "%d", self->port);
-    }
-    else
-    if (streq (method, "CONFIGURE")) {
-        char *config_file = zmsg_popstr (msg);
-        zconfig_destroy (&self->config);
-        self->config = zconfig_load (config_file);
-        if (self->config) {
-            s_server_apply_config (self);
-            self->server.config = self->config;
+    while (zsock_events (self->pipe) & ZMQ_POLLIN) {
+        zmsg_t *msg = zmsg_recv (self->pipe);
+        if (!msg)
+            return -1;              //  Interrupted; exit zloop
+        char *method = zmsg_popstr (msg);
+        if (self->verbose)
+            zsys_debug ("%s:     API command=%s", self->log_prefix, method);
+
+        if (streq (method, "VERBOSE"))
+            self->verbose = true;
+        else
+        if (streq (method, "$TERM")) {
+            //  Shutdown the engine
+            free (method);
+            zmsg_destroy (&msg);
+            return -1;
+        }
+        else
+        if (streq (method, "BIND")) {
+            //  Bind to a specified endpoint, which may use an ephemeral port
+            char *endpoint = zmsg_popstr (msg);
+            self->port = zsock_bind (self->router, "%s", endpoint);
+            if (self->port == -1)
+                zsys_warning ("could not bind to %s", endpoint);
+            free (endpoint);
+        }
+        else
+        if (streq (method, "PORT")) {
+            //  Return PORT + port number from the last bind, if any
+            zstr_sendm (self->pipe, "PORT");
+            zstr_sendf (self->pipe, "%d", self->port);
+        }
+        else
+        if (streq (method, "CONFIGURE")) {
+            char *config_file = zmsg_popstr (msg);
+            zconfig_destroy (&self->config);
+            self->config = zconfig_load (config_file);
+            if (self->config) {
+                s_server_apply_config (self);
+                self->server.config = self->config;
+            }
+            else {
+                zsys_warning ("cannot load config file '%s'\n", config_file);
+                self->config = zconfig_new ("root", NULL);
+            }
+            free (config_file);
+        }
+        else
+        if (streq (method, "SET")) {
+            char *path = zmsg_popstr (msg);
+            char *value = zmsg_popstr (msg);
+            zconfig_put (self->config, path, value);
+            if (streq (path, "server/animate")) {
+                zsys_warning ("'%s' is deprecated, use VERBOSE command instead", path);
+                self->verbose = atoi (value);
+            }
+            s_server_config_self (self);
+            free (path);
+            free (value);
         }
         else {
-            zsys_warning ("cannot load config file '%s'\n", config_file);
-            self->config = zconfig_new ("root", NULL);
+            //  Execute custom method
+            zmsg_t *reply = server_method (&self->server, method, msg);
+            //  If reply isn't null, send it to caller
+            zmsg_send (&reply, self->pipe);
         }
-        free (config_file);
+        free (method);
+        zmsg_destroy (&msg);
     }
-    else
-    if (streq (method, "SET")) {
-        char *path = zmsg_popstr (msg);
-        char *value = zmsg_popstr (msg);
-        zconfig_put (self->config, path, value);
-        if (streq (path, "server/animate")) {
-            zsys_warning ("'%s' is deprecated, use VERBOSE command instead", path);
-            self->verbose = atoi (value);
-        }
-        s_server_config_self (self);
-        free (path);
-        free (value);
-    }
-    else {
-        //  Execute custom method
-        zmsg_t *reply = server_method (&self->server, method, msg);
-        //  If reply isn't null, send it to caller
-        zmsg_send (&reply, self->pipe);
-    }
-    free (method);
-    zmsg_destroy (&msg);
     return 0;
 }
 
 //  Handle a message (a protocol request) from the client
 
 static int
-s_server_client_message (zloop_t *loop, zsock_t *reader, void *argument)
+s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
 {
     s_server_t *self = (s_server_t *) argument;
-    mlm_msg_t *msg = mlm_msg_recv (self->router);
-    if (!msg)
-        return -1;              //  Interrupted; exit zloop
+    //  We will process as many messages as we can, to reduce the overhead
+    //  of polling and the reactor:
+    while (zsock_events (self->router) & ZMQ_POLLIN) {
+        mlm_msg_t *msg = mlm_msg_recv (self->router);
+        if (!msg)
+            return -1;              //  Interrupted; exit zloop
 
-    char *hashkey = zframe_strhex (mlm_msg_routing_id (msg));
-    s_client_t *client = (s_client_t *) zhash_lookup (self->clients, hashkey);
-    if (client == NULL) {
-        client = s_client_new (self, mlm_msg_routing_id (msg));
-        zhash_insert (self->clients, hashkey, client);
-        zhash_freefn (self->clients, hashkey, s_client_free);
-    }
-    free (hashkey);
+        char *hashkey = zframe_strhex (mlm_msg_routing_id (msg));
+        s_client_t *client = (s_client_t *) zhash_lookup (self->clients, hashkey);
+        if (client == NULL) {
+            client = s_client_new (self, mlm_msg_routing_id (msg));
+            zhash_insert (self->clients, hashkey, client);
+            zhash_freefn (self->clients, hashkey, s_client_free);
+        }
+        free (hashkey);
 
-    //  Any input from client counts as activity
-    if (client->expiry_timer) {
-        zloop_timer_end (self->loop, client->expiry_timer);
-        client->expiry_timer = 0;
+        //  Any input from client counts as activity
+        if (client->expiry_timer) {
+            zloop_timer_end (self->loop, client->expiry_timer);
+            client->expiry_timer = 0;
+        }
+        //  Reset expiry timer if timeout is not zero
+        if (self->timeout)
+            client->expiry_timer = zloop_timer (
+                self->loop, self->timeout, 1, s_client_handle_timeout, client);
+
+        //  Queue request and possibly pass it to client state machine
+        zlist_append (client->mailbox, msg);
+        event_t event = s_client_filter_mailbox (client);
+        if (event != NULL_event)
+            s_client_execute (client, event);
     }
-    //  Reset expiry timer if timeout is not zero
-    if (self->timeout)
-        client->expiry_timer = zloop_timer (
-            self->loop, self->timeout, 1, s_client_handle_timeout, client);
-        
-    //  Queue request and possibly pass it to client state machine
-    zlist_append (client->mailbox, msg);
-    event_t event = s_client_filter_mailbox (client);
-    if (event != NULL_event)
-        s_client_execute (client, event);
-        
     return 0;
 }
 
@@ -1177,8 +1182,8 @@ mlm_server (zsock_t *pipe, void *args)
     //  Set-up server monitor to watch for config file changes
     engine_set_monitor ((server_t *) self, 1000, s_watch_server_config);
     //  Set up handler for the two main sockets the server uses
-    engine_handle_socket ((server_t *) self, self->pipe, s_server_api_message);
-    engine_handle_socket ((server_t *) self, self->router, s_server_client_message);
+    engine_handle_socket ((server_t *) self, self->pipe, s_server_handle_pipe);
+    engine_handle_socket ((server_t *) self, self->router, s_server_handle_protocol);
 
     //  Run reactor until there's a termination signal
     zloop_start (self->loop);

--- a/src/perftest.c
+++ b/src/perftest.c
@@ -1,0 +1,57 @@
+/*  =========================================================================
+    perftest.c - Malamute performance tester
+
+    Runs various tests on Malamute to test performance of the core engines.
+
+    Copyright (c) the Contributors as noted in the AUTHORS file.
+    This file is part of the Malamute Project.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+    =========================================================================
+*/
+
+//  This header file gives us the Malamute APIs plus Zyre, CZMQ, and libzmq:
+#include "../include/malamute.h"
+
+int main (int argc, char *argv [])
+{
+    //  We will remove all buffer limits on internal plumbing; instead,
+    //  we use credit-based flow control to rate-limit traffic per client.
+    //  If we allow limits, then the engines will block under stress.
+    zsys_set_pipehwm (0);
+    zsys_set_sndhwm (0);
+    zsys_set_rcvhwm (0);
+    
+    zactor_t *broker = zactor_new (mlm_server, NULL);
+    zsock_send (broker, "ss", "BIND", "ipc://@/mlm");
+//     zsock_send (broker, "s", "VERBOSE");
+
+    //  1. Throughput test with minimal density
+    mlm_client_t *reader = mlm_client_new ("ipc://@/mlm", 0);
+    mlm_client_t *writer = mlm_client_new ("ipc://@/mlm", 0);
+    mlm_client_produce (writer, "weather");
+    mlm_client_consume (reader, "weather", "temp.*");
+
+    int64_t start = zclock_time ();
+    int count = 100000;
+    while (count) {
+        mlm_client_send (writer, "temp.moscow", "10");
+        mlm_client_send (writer, "rain.moscow", "0");
+        count--;
+    }
+    mlm_client_send (writer, "temp.signal", "END");
+    while (true) {
+        char *message = mlm_client_recv (reader);
+        if (streq (message, "END"))
+            break;
+        count++;
+    }
+    printf (" -- sending %d messages: %d msec\n", count, (int) (zclock_time () - start));
+    mlm_client_destroy (&reader);
+    mlm_client_destroy (&writer);
+    
+    zactor_destroy (&broker);
+    return 0;
+}


### PR DESCRIPTION
It takes about 3 seconds to send 100K messages from client to server
to client, i.e. 200K messages in total, or 65K / second.

Solution: start by rewriting message codec to reduce use of heap
memory.
