### PR TITLE
Changed default ipc endpoint to inproc and tcp for portability

### DIFF
--- a/src/malamute.cfg
+++ b/src/malamute.cfg
@@ -9,11 +9,11 @@ server
     auth
         verbose = 1     #   Debug authentication steps?
         plain = passwords.cfg
-    
+
 #   Apply to the Malamute service
 mlm_server
-    echo = binding Malamute service to 'ipc://@/malamute'
+    echo = binding Malamute service to 'tcp://*:9999'
     security
         mechanism = plain
     bind
-        endpoint = ipc://@/malamute
+        endpoint = tcp://*:9999

--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -287,7 +287,7 @@ mlm_client_test (bool verbose)
 
     //  @selftest
     mlm_client_verbose = verbose;
-    
+
     //  Start a server to test against, and bind to endpoint
     zactor_t *server = zactor_new (mlm_server, "mlm_client_test");
     if (verbose)
@@ -309,14 +309,14 @@ mlm_client_test (bool verbose)
     assert (writer);
     int rc = mlm_client_set_plain_auth (writer, "writer", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (writer, "ipc://@/malamute", 1000, "writer");
+    rc = mlm_client_connect (writer, "inproc://malamute", 1000, "writer");
     assert (rc == 0);
 
     mlm_client_t *reader = mlm_client_new ();
     assert (reader);
     rc = mlm_client_set_plain_auth (reader, "reader", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (reader, "ipc://@/malamute", 1000, "");
+    rc = mlm_client_connect (reader, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
     mlm_client_set_producer (writer, "weather");
@@ -354,7 +354,7 @@ mlm_client_test (bool verbose)
     assert (streq (mlm_client_sender (reader), "writer"));
     zstr_free (&subject);
     zstr_free (&content);
-    
+
     mlm_client_destroy (&reader);
 
     //  Test mailbox pattern
@@ -362,7 +362,7 @@ mlm_client_test (bool verbose)
     assert (reader);
     rc = mlm_client_set_plain_auth (reader, "reader", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (reader, "ipc://@/malamute", 1000, "mailbox");
+    rc = mlm_client_connect (reader, "inproc://malamute", 1000, "mailbox");
     assert (rc == 0);
 
     mlm_client_sendtox (writer, "mailbox", "subject 1", "Message 1", "attachment", NULL);
@@ -388,7 +388,7 @@ mlm_client_test (bool verbose)
     assert (reader);
     rc = mlm_client_set_plain_auth (reader, "reader", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (reader, "ipc://@/malamute", 500, "mailbox");
+    rc = mlm_client_connect (reader, "inproc://malamute", 500, "mailbox");
     assert (rc == 0);
 
     mlm_client_recvx (reader, &subject, &content, &attach, NULL);
@@ -445,21 +445,21 @@ mlm_client_test (bool verbose)
     assert (writer);
     rc = mlm_client_set_plain_auth (writer, "writer", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (writer, "ipc://@/malamute", 1000, "");
+    rc = mlm_client_connect (writer, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
     mlm_client_t *reader1 = mlm_client_new ();
     assert (reader1);
     rc = mlm_client_set_plain_auth (reader1, "reader", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (reader1, "ipc://@/malamute", 1000, "");
+    rc = mlm_client_connect (reader1, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
     mlm_client_t *reader2 = mlm_client_new ();
     assert (reader2);
     rc = mlm_client_set_plain_auth (reader2, "reader", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (reader2, "ipc://@/malamute", 1000, "");
+    rc = mlm_client_connect (reader2, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
     mlm_client_set_producer (writer, "weather");
@@ -483,7 +483,7 @@ mlm_client_test (bool verbose)
     mlm_client_destroy (&writer);
     mlm_client_destroy (&reader1);
     mlm_client_destroy (&reader2);
-    
+
     //  Done, shut down
     zactor_destroy (&auth);
     zactor_destroy (&server);

--- a/src/mlm_client.cfg
+++ b/src/mlm_client.cfg
@@ -8,11 +8,11 @@ server
     verbose = 0         #   Do verbose logging of activity?
     auth
         plain = src/passwords.cfg
-    
+
 #   Apply to the Malamute service
 #   Note security settings must come before binds
 mlm_server
     security
         mechanism = plain
     bind
-        endpoint = ipc://@/malamute
+        endpoint = inproc://malamute

--- a/src/mlm_perftest.c
+++ b/src/mlm_perftest.c
@@ -23,20 +23,20 @@ int main (int argc, char *argv [])
     zsys_set_pipehwm (0);
     zsys_set_sndhwm (0);
     zsys_set_rcvhwm (0);
-    
+
     zactor_t *broker = zactor_new (mlm_server, NULL);
-    zsock_send (broker, "ss", "BIND", "ipc://@/malamute");
+    zsock_send (broker, "ss", "BIND", "inproc://malamute");
 //     zsock_send (broker, "s", "VERBOSE");
 
     //  1. Throughput test with minimal density
     mlm_client_t *reader = mlm_client_new ();
     assert (reader);
-    int rc = mlm_client_connect (reader, "ipc://@/malamute", 0, "reader");
+    int rc = mlm_client_connect (reader, "inproc://malamute", 0, "reader");
     assert (rc == 0);
 
     mlm_client_t *writer = mlm_client_new ();
     assert (writer);
-    rc = mlm_client_connect (writer, "ipc://@/malamute", 0, "writer");
+    rc = mlm_client_connect (writer, "inproc://malamute", 0, "writer");
     assert (rc == 0);
 
     mlm_client_set_producer (writer, "weather");
@@ -47,14 +47,14 @@ int main (int argc, char *argv [])
     if (argc > 1)
         count = atoi (argv [1]);
     printf ("COUNT=%d\n", count);
-    
+
     while (count) {
         mlm_client_sendx (writer, "temp.moscow", "10", NULL);
         mlm_client_sendx (writer, "rain.moscow", "0", NULL);
         count--;
     }
     mlm_client_sendx (writer, "temp.signal", "END", NULL);
-    
+
     while (true) {
         zmsg_t *msg = mlm_client_recv (reader);
         assert (msg);
@@ -66,7 +66,7 @@ int main (int argc, char *argv [])
     printf (" -- sending %d messages: %d msec\n", count, (int) (zclock_time () - start));
     mlm_client_destroy (&reader);
     mlm_client_destroy (&writer);
-    
+
     zactor_destroy (&broker);
     printf (" -- total number of allocs: %" PRId64 ", %d/msg\n", zsys_allocs,
             (int) (zsys_allocs / count));

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -1,12 +1,12 @@
 /*  =========================================================================
     mlm_server - Malamute Server
 
-    Copyright (c) the Contributors as noted in the AUTHORS file.       
+    Copyright (c) the Contributors as noted in the AUTHORS file.
     This file is part of the Malamute Project.
-                                                                       
+
     This Source Code Form is subject to the terms of the Mozilla Public
     License, v. 2.0. If a copy of the MPL was not distributed with this
-    file, You can obtain one at http://mozilla.org/MPL/2.0/.           
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
     =========================================================================
 */
 
@@ -426,11 +426,11 @@ write_message_to_mailbox (client_t *self)
         mlm_proto_tracker (self->message),
         mlm_proto_timeout (self->message),
         mlm_proto_get_content (self->message));
-        
+
     //  Try to dispatch to client immediately, if it's connected
     client_t *target = (client_t *) zhashx_lookup (
         self->server->clients, mlm_proto_address (self->message));
-    
+
     if (target) {
         assert (!target->msg);
         target->msg = msg;
@@ -457,7 +457,7 @@ write_message_to_service (client_t *self)
         mlm_proto_tracker (self->message),
         mlm_proto_timeout (self->message),
         mlm_proto_get_content (self->message));
-        
+
     service_t *service = s_service_require (self, mlm_proto_address (self->message));
     assert (service);
     zlistx_add_end (service->queue, msg);
@@ -612,16 +612,16 @@ mlm_server_test (bool verbose)
     printf (" * mlm_server: ");
     if (verbose)
         printf ("\n");
-    
+
     //  @selftest
     zactor_t *server = zactor_new (mlm_server, "mlm_server_test");
     if (verbose)
         zstr_send (server, "VERBOSE");
-    zstr_sendx (server, "BIND", "ipc://@/malamute", NULL);
+    zstr_sendx (server, "BIND", "inproc://malamute", NULL);
 
     zsock_t *reader = zsock_new (ZMQ_DEALER);
     assert (reader);
-    zsock_connect (reader, "ipc://@/malamute");
+    zsock_connect (reader, "inproc://malamute");
     zsock_set_rcvtimeo (reader, 500);
 
     mlm_proto_t *proto = mlm_proto_new ();
@@ -636,7 +636,7 @@ mlm_server_test (bool verbose)
     //  Now do a stream publish-subscribe test
     zsock_t *writer = zsock_new (ZMQ_DEALER);
     assert (writer);
-    zsock_connect (writer, "ipc://@/malamute");
+    zsock_connect (writer, "inproc://malamute");
     zsock_set_rcvtimeo (reader, 500);
 
     //  Open connections from both reader and writer
@@ -692,12 +692,12 @@ mlm_server_test (bool verbose)
     assert (streq (mlm_proto_subject (proto), "temp.london"));
 
     mlm_proto_destroy (&proto);
-        
+
     //  Finished, we can clean up
     zsock_destroy (&writer);
     zsock_destroy (&reader);
     zactor_destroy (&server);
-    
+
     //  @end
     printf ("OK\n");
 }

--- a/src/mlm_tutorial.c
+++ b/src/mlm_tutorial.c
@@ -60,17 +60,17 @@ int main (int argc, char *argv [])
     //  where the username maps to a mailbox name
     mlm_client_t *reader = mlm_client_new ();
     assert (reader);
-    int rc = mlm_client_connect (reader, "ipc://@/malamute", 1000, "reader/secret");
+    int rc = mlm_client_connect (reader, "inproc://malamute", 1000, "reader/secret");
     assert (rc == 0);
 
     mlm_client_t *writer = mlm_client_new ();
     assert (writer);
-    rc = mlm_client_connect (writer, "ipc://@/malamute", 1000, "writer/secret");
+    rc = mlm_client_connect (writer, "inproc://malamute", 1000, "writer/secret");
     assert (rc == 0);
 
     //  The writer publishes to the "weather" stream
     mlm_client_set_producer (writer, "weather");
-    
+
     //  The reader consumes temperature messages off the "weather" stream
     mlm_client_set_consumer (reader, "weather", "temp.*");
 
@@ -98,14 +98,14 @@ int main (int argc, char *argv [])
     assert (streq (mlm_client_command (reader), "STREAM DELIVER"));
     assert (streq (mlm_client_sender (reader), "writer"));
     assert (streq (mlm_client_address (reader), "weather"));
-    
+
     //  Let's get the other two messages:
     mlm_client_recvx (reader, &subject, &content, NULL);
     assert (streq (subject, "temp.madrid"));
     assert (streq (content, "3"));
     zstr_free (&subject);
     zstr_free (&content);
-    
+
     mlm_client_recvx (reader, &subject, &content, NULL);
     assert (streq (subject, "temp.london"));
     assert (streq (content, "5"));
@@ -116,7 +116,7 @@ int main (int argc, char *argv [])
     //  which does a proper deconnect handshake internally:
     mlm_client_destroy (&reader);
     mlm_client_destroy (&writer);
-    
+
     //  Finally, shut down the broker by destroying the actor; this does
     //  a proper shutdown so that all memory is freed as you'd expect.
     zactor_destroy (&broker);

--- a/src/mshell.c
+++ b/src/mshell.c
@@ -8,7 +8,7 @@
     mshell stream pattern         -- show all matching messages
     mshell stream subject message -- send message to stream / subject
 
-    By default connects to a broker at ipc://@/malamute; to connect to
+    By default connects to a broker at inproc://malamute; to connect to
     another endpoint, use the option -e endpoint.
 
     This Source Code Form is subject to the terms of the Mozilla Public
@@ -26,7 +26,7 @@ int main (int argc, char *argv [])
     bool null_auth = false;
     char *username = "mshell";
     char *password = "mshell";
-    char *endpoint = "ipc://@/malamute";
+    char *endpoint = "tcp://127.0.0.1:9999";
     if (argc > argn && streq (argv [argn], "-v")) {
         verbose = true;
         argn++;
@@ -59,7 +59,7 @@ int main (int argc, char *argv [])
 
     if (!null_auth)
         mlm_client_set_plain_auth (client, username, password);
-    
+
     if (mlm_client_connect (client, endpoint, 1000, "")) {
         zsys_error ("mshell: server not reachable at %s", endpoint);
         mlm_client_destroy (&client);


### PR DESCRIPTION
The default ipc endpoint is not portable to other systems
like OSX or Windows. Changed it to inproc and tcp where was
the case.