### PR TITLE
Problem: address is always empty in STREAM DELIVER

### DIFF
--- a/include/mlm_client.h
+++ b/include/mlm_client.h
@@ -76,7 +76,7 @@ MLM_EXPORT int
 MLM_EXPORT int 
     mlm_client_set_producer (mlm_client_t *self, const char *stream);
 
-//  Consume messages with matching addresses. The pattern is a regular expression   
+//  Consume messages with matching subjects. The pattern is a regular expression    
 //  using the CZMQ zrex syntax. The most useful elements are: ^ and $ to match the  
 //  start and end, . to match any character, \s and \S to match whitespace and      
 //  non-whitespace, \d and \D to match a digit and non-digit, \a and \A to match    

--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -165,7 +165,7 @@ pass_stream_message_to_app (client_t *self)
 {
     zstr_sendm (self->msgpipe, "STREAM DELIVER");
     zsock_bsend (self->msgpipe, "sssp",
-                 mlm_proto_stream (self->message),
+                 mlm_proto_address (self->message),
                  mlm_proto_sender (self->message),
                  mlm_proto_subject (self->message),
                  mlm_proto_get_content (self->message));
@@ -281,9 +281,7 @@ signal_server_not_present (client_t *self)
 void
 mlm_client_test (bool verbose)
 {
-    printf (" * mlm_client: ");
-    if (verbose)
-        printf ("\n");
+    printf (" * mlm_client: \n");
 
     //  @selftest
     mlm_client_verbose = verbose;
@@ -440,12 +438,19 @@ mlm_client_test (bool verbose)
     zstr_free (&content);
     mlm_client_destroy (&reader);
 
-    //  Test multiple readers for same message
-    writer = mlm_client_new ();
-    assert (writer);
-    rc = mlm_client_set_plain_auth (writer, "writer", "secret");
+    //  Test multiple readers and multiple writers
+    mlm_client_t *writer1 = mlm_client_new ();
+    assert (writer1);
+    rc = mlm_client_set_plain_auth (writer1, "writer", "secret");
     assert (rc == 0);
-    rc = mlm_client_connect (writer, "inproc://malamute", 1000, "");
+    rc = mlm_client_connect (writer1, "inproc://malamute", 1000, "");
+    assert (rc == 0);
+
+    mlm_client_t *writer2 = mlm_client_new ();
+    assert (writer2);
+    rc = mlm_client_set_plain_auth (writer2, "writer", "secret");
+    assert (rc == 0);
+    rc = mlm_client_connect (writer2, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
     mlm_client_t *reader1 = mlm_client_new ();
@@ -462,25 +467,47 @@ mlm_client_test (bool verbose)
     rc = mlm_client_connect (reader2, "inproc://malamute", 1000, "");
     assert (rc == 0);
 
-    mlm_client_set_producer (writer, "weather");
-    mlm_client_set_consumer (reader1, "weather", "temp.*");
-    mlm_client_set_consumer (reader2, "weather", "temp.*");
+    mlm_client_set_producer (writer1, "weather");
+    mlm_client_set_producer (writer2, "traffic");
+    mlm_client_set_consumer (reader1, "weather", "newyork");
+    mlm_client_set_consumer (reader1, "traffic", "newyork");
+    mlm_client_set_consumer (reader2, "weather", "newyork");
+    mlm_client_set_consumer (reader2, "traffic", "newyork");
 
-    mlm_client_sendx (writer, "temp.newyork", "8", NULL);
+    mlm_client_sendx (writer1, "newyork", "8", NULL);
 
     mlm_client_recvx (reader1, &subject, &content, NULL);
-    assert (streq (subject, "temp.newyork"));
+    assert (streq (mlm_client_address (reader1), "weather"));
+    assert (streq (subject, "newyork"));
     assert (streq (content, "8"));
     zstr_free (&subject);
     zstr_free (&content);
 
     mlm_client_recvx (reader2, &subject, &content, NULL);
-    assert (streq (subject, "temp.newyork"));
+    assert (streq (mlm_client_address (reader2), "weather"));
+    assert (streq (subject, "newyork"));
     assert (streq (content, "8"));
     zstr_free (&subject);
     zstr_free (&content);
 
-    mlm_client_destroy (&writer);
+    mlm_client_sendx (writer2, "newyork", "85", NULL);
+
+    mlm_client_recvx (reader1, &subject, &content, NULL);
+    assert (streq (mlm_client_address (reader1), "traffic"));
+    assert (streq (subject, "newyork"));
+    assert (streq (content, "85"));
+    zstr_free (&subject);
+    zstr_free (&content);
+
+    mlm_client_recvx (reader2, &subject, &content, NULL);
+    assert (streq (mlm_client_address (reader2), "traffic"));
+    assert (streq (subject, "newyork"));
+    assert (streq (content, "85"));
+    zstr_free (&subject);
+    zstr_free (&content);
+
+    mlm_client_destroy (&writer1);
+    mlm_client_destroy (&writer2);
     mlm_client_destroy (&reader1);
     mlm_client_destroy (&reader2);
 

--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -165,7 +165,7 @@
     </method>
 
     <method name = "set consumer" return = "status">
-    Consume messages with matching addresses. The pattern is a regular
+    Consume messages with matching subjects. The pattern is a regular
     expression using the CZMQ zrex syntax. The most useful elements are:
     ^ and $ to match the start and end, . to match any character, \s and
     \S to match whitespace and non-whitespace, \d and \D to match a digit

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1282,7 +1282,7 @@ mlm_client_set_producer (mlm_client_t *self, const char *stream)
 
 
 //  ---------------------------------------------------------------------------
-//  Consume messages with matching addresses. The pattern is a regular expression   
+//  Consume messages with matching subjects. The pattern is a regular expression    
 //  using the CZMQ zrex syntax. The most useful elements are: ^ and $ to match the  
 //  start and end, . to match any character, \s and \S to match whitespace and      
 //  non-whitespace, \d and \D to match a digit and non-digit, \a and \A to match    

--- a/src/mlm_msg.c
+++ b/src/mlm_msg.c
@@ -88,6 +88,16 @@ mlm_msg_subject (mlm_msg_t *self)
 
 
 //  --------------------------------------------------------------------------
+//  Return message address
+
+char *
+mlm_msg_address (mlm_msg_t *self)
+{
+    return self->address;
+}
+
+
+//  --------------------------------------------------------------------------
 //  Store message into mlm_proto object
 
 void

--- a/src/mlm_msg.h
+++ b/src/mlm_msg.h
@@ -22,32 +22,36 @@ typedef struct _mlm_msg_t mlm_msg_t;
 //  @interface
 //  Create a new mlm_msg; takes ownership of content, which the caller should
 //  not use after this call.
-MLM_EXPORT mlm_msg_t *
+mlm_msg_t *
     mlm_msg_new (const char *sender, const char *address, const char *subject,
                  const char *tracker, uint timeout, zmsg_t *content);
 
 //  Destroy the mlm_msg
-MLM_EXPORT void
+void
     mlm_msg_destroy (mlm_msg_t **self_p);
 
 //  Return message subject
-MLM_EXPORT char *
+char *
     mlm_msg_subject (mlm_msg_t *self);
 
+//  Return message address
+char *
+    mlm_msg_address (mlm_msg_t *self);
+
 //  Store message into mlm_proto object
-MLM_EXPORT void
+void
     mlm_msg_set_proto (mlm_msg_t *self, mlm_proto_t *proto);
 
 //  Get reference-counted copy of message
-MLM_EXPORT mlm_msg_t *
+mlm_msg_t *
     mlm_msg_link (mlm_msg_t *self);
 
 //  Drop reference to message
-MLM_EXPORT void
+void
     mlm_msg_unlink (mlm_msg_t **self_p);
 
 //  Self test of this class
-MLM_EXPORT int
+int
     mlm_msg_test (bool verbose);
 //  @end
 


### PR DESCRIPTION
Solution: set this to stream name, as it should be.

Problem: sender is always empty in client API

Solution: return sender name properly

I extended the mlm_client.c self tests with checks for both these
problems.

Fixes #67