### PR TITLE
Problem: malamute segfaults when deregistering client

### DIFF
--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -588,7 +588,7 @@ deregister_the_client (client_t *self)
         }
         service = (service_t *) zhashx_next (self->server->services);
     }
-    if (*self->address)
+    if (self->address && *self->address)
         zhashx_delete (self->server->clients, self->address);
     mlm_proto_set_status_code (self->message, MLM_PROTO_SUCCESS);
 }


### PR DESCRIPTION
Solution: fix the NULL pointer dereference

The stacktrace is
 #0  0x00007fcabb651a3d in deregister_the_client
(self=self@entry=0x7fcaac00df50) at src/mlm_server.c:574
 #1  0x00007fcabb6527ab in s_client_execute
(self=self@entry=0x7fcaac00df50, event=<optimized out>) at
src/mlm_server_engine.inc:1089
 #2  0x00007fcabb65345b in s_server_handle_protocol (loop=<optimized
out>, reader=<optimized out>, argument=0x7fcaac0008c0) at
src/mlm_server_engine.inc:1405
 #3  0x00007fcabb3d1c7d in zloop_start (self=0x7fcaac0024b0) at
src/zloop.c:818
 #4  0x00007fcabb6538b3 in mlm_server (pipe=0x1d99af0, args=0x4013fb) at
src/mlm_server_engine.inc:1448
 #5  0x00007fcabb3bbb53 in s_thread_shim (args=0x1d96190) at
src/zactor.c:67
 #6  0x00007fcaba4cd0a4 in start_thread (arg=0x7fcab3fff700) at
pthread_create.c:309
 #7  0x00007fcabb0e406d in clone () at
../sysdeps/unix/sysv/linux/x86_64/clone.S:111

It seems that client without address (is that possible) are not handled
well and leads to malamute segfault.