### PR TITLE
Problem: Self tests are crashing on ARM

### DIFF
--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1275,10 +1275,10 @@ bool
 mlm_client_connected (mlm_client_t *self)
 {
     assert (self);
-    bool connected;
+    int connected;
     zsock_send (self->actor, "s", "$CONNECTED");
     zsock_recv (self->actor, "i", &connected);
-    return connected;
+    return connected!=0;
 }
 
 


### PR DESCRIPTION
Solution: bool doesn't need to have the same size as int, so just to be
sure using int.