### PR TITLE
Add a Dockerfile that builds a statically compiled malalute with MUSL libc

### DIFF
--- a/builds/static/Dockerfile
+++ b/builds/static/Dockerfile
@@ -1,0 +1,46 @@
+FROM voidlinux/voidlinux-musl
+MAINTAINER Benjamin Henrion <zoobab@gmail.com>
+
+RUN xbps-install -Su
+RUN xbps-install -Sy git make gcc gcc-c++ libtool autoconf automake pkg-config
+
+RUN useradd -d /home/zmq -m -s /bin/bash zmq
+RUN echo "zmq ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/zmq
+RUN chmod 0440 /etc/sudoers.d/zmq
+
+USER zmq
+
+WORKDIR /home/zmq
+RUN git clone git://github.com/jedisct1/libsodium.git
+WORKDIR /home/zmq/libsodium
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr
+RUN make
+RUN sudo make install
+
+WORKDIR /home/zmq
+RUN git clone git://github.com/zeromq/libzmq.git
+WORKDIR /home/zmq/libzmq
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr
+RUN make
+RUN sudo make install
+
+WORKDIR /home/zmq
+RUN git clone git://github.com/zeromq/czmq.git
+WORKDIR /home/zmq/czmq
+RUN ./autogen.sh
+RUN ./configure --prefix=/usr
+RUN make
+RUN sudo make install
+
+WORKDIR /home/zmq
+RUN git clone git://github.com/zeromq/malamute.git
+WORKDIR /home/zmq/malamute
+RUN ./autogen.sh
+RUN ./configure --disable-shared --prefix=/usr
+# "-s" will strip the symbols and make the binary smaller
+RUN make LDFLAGS="-all-static -s"
+RUN sudo make install
+# ldd returns an exit code of 0 if the binary is dynamic, 1 if it is a static, here the "!" reverts the test to make it successful if it is a static
+RUN ! ldd /usr/bin/malamute

--- a/builds/static/build.sh
+++ b/builds/static/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t malamute-static:latest .


### PR DESCRIPTION
Add a Dockerfile that builds a statically compiled malalute with MUSL libc.

Glibc was causing problems (see here http://permalink.gmane.org/gmane.network.zeromq.devel/27492), so I had to switch to MUSL libc, which is lighter and less hostile to static binaries (Read "The GCC/Linux developer community is sold on shared library executables" http://www.staticramlinux.com/BuildingStaticCompiler.html).

A complete build image is also available here:

https://hub.docker.com/r/zoobab/malamute-static/

$ docker pull zoobab/malamute-static