### PR TITLE
Problem: Some executables are still broken.

### DIFF
--- a/src/mlm_perftest.c
+++ b/src/mlm_perftest.c
@@ -13,7 +13,7 @@
 */
 
 //  This header file gives us the Malamute APIs plus Zyre, CZMQ, and libzmq:
-#include "../include/malamute.h"
+#include "mlm_classes.h"
 
 int main (int argc, char *argv [])
 {

--- a/src/mlm_tutorial.c
+++ b/src/mlm_tutorial.c
@@ -15,7 +15,7 @@
 */
 
 //  This header file gives us the Malamute APIs plus Zyre, CZMQ, and libzmq:
-#include "../include/malamute.h"
+#include "mlm_classes.h"
 
 int main (int argc, char *argv [])
 {

--- a/src/mshell.c
+++ b/src/mshell.c
@@ -17,7 +17,7 @@
     =========================================================================
 */
 
-#include "malamute.h"
+#include "mlm_classes.h"
 
 int main (int argc, char *argv [])
 {


### PR DESCRIPTION
Solution: include mlm_classes.c instead of malamute.h in all of them.