### PR TITLE
Problem: Travis does not let us know that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ sudo: false
 
 env:
 - BUILD_TYPE=default
+- BUILD_TYPE=check_zproject
+
+services: 
+- docker
 
 addons:
   apt:

--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+docker run -v "$REPO_DIR":/gsl zeromqorg/zproject project.xml
+
+if [[ $(git diff) ]]; then
+    exit 1
+fi
+if [[ $(git status -s) ]]; then
+    exit 1
+fi

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -7,7 +7,7 @@
 
 set -x
 
-if [ $BUILD_TYPE == "default" ]; then
+if [ "$BUILD_TYPE" == "default" ]; then
     mkdir tmp
     BUILD_PREFIX=$PWD/tmp
 
@@ -32,5 +32,5 @@ if [ $BUILD_TYPE == "default" ]; then
     # Build and check this project
     ( ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make memcheck && make install ) || exit 1
 else
-    cd ./builds/${BUILD_TYPE} && ./ci_build.sh
+     pushd "./builds/${BUILD_TYPE}" && REPO_DIR="$(dirs -l +1)" ./ci_build.sh
 fi


### PR DESCRIPTION
zproject has not run

Solution: Add a build that fails if code in repo differs from
code generated with latest Travis