### PR TITLE
Problem: termination of not connected client crashes the application

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -392,6 +392,18 @@ mlm_client_test (bool verbose)
     //  @selftest
     mlm_client_verbose = verbose;
 
+    // test api, when client is not connected at all
+    mlm_client_t *not_connected_client = mlm_client_new ();
+    assert (not_connected_client);
+    int rc = mlm_client_set_producer (not_connected_client, "weather");
+    assert (mlm_client_connected (not_connected_client) == false);
+    assert ( rc == -1 );
+    rc = mlm_client_set_consumer (not_connected_client, "weather", ".*");
+    assert (mlm_client_connected (not_connected_client) == false);
+    assert ( rc == -1 );
+    rc = mlm_client_set_worker (not_connected_client, "weather", ".*");
+    mlm_client_destroy (&not_connected_client);
+
     //  Start a server to test against, and bind to endpoint
     zactor_t *server = zactor_new (mlm_server, "mlm_client_test");
     if (verbose)
@@ -411,7 +423,7 @@ mlm_client_test (bool verbose)
     //  Test stream pattern
     mlm_client_t *writer = mlm_client_new ();
     assert (writer);
-    int rc = mlm_client_set_plain_auth (writer, "writer", "secret");
+    rc = mlm_client_set_plain_auth (writer, "writer", "secret");
     assert (rc == 0);
     assert (mlm_client_connected (writer) == false);
     rc = mlm_client_connect (writer, "tcp://127.0.0.1:9999", 1000, "writer");

--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -26,6 +26,22 @@
         </event>
         <event name = "destructor">
             <action name = "signal success" />
+            <action name = "terminate" />
+        </event>
+        <!-- before we can do this, we need to connect -> immidiatly generate fail -->
+        <event name = "set producer">
+            <action name = "signal failure" />
+        </event>
+        <!-- before we can do this, we need to connect -> immidiatly generate fail -->
+        <event name = "set consumer">
+            <action name = "signal failure" />
+        </event>
+        <!-- before we can do this, we need to connect -> immidiatly generate fail -->
+        <event name = "set worker">
+            <action name = "signal failure" />
+        </event>
+        <event name = "*">
+            <!-- Discard any other incoming events -->
         </event>
     </state>
 

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -42,11 +42,11 @@ typedef enum {
     connect_event = 2,
     bad_endpoint_event = 3,
     destructor_event = 4,
-    ok_event = 5,
-    expired_event = 6,
-    set_producer_event = 7,
-    set_consumer_event = 8,
-    set_worker_event = 9,
+    set_producer_event = 5,
+    set_consumer_event = 6,
+    set_worker_event = 7,
+    ok_event = 8,
+    expired_event = 9,
     stream_deliver_event = 10,
     mailbox_deliver_event = 11,
     service_deliver_event = 12,
@@ -81,11 +81,11 @@ s_event_name [] = {
     "connect",
     "bad_endpoint",
     "destructor",
-    "OK",
-    "expired",
     "set_producer",
     "set_consumer",
     "set_worker",
+    "OK",
+    "expired",
     "STREAM_DELIVER",
     "MAILBOX_DELIVER",
     "SERVICE_DELIVER",
@@ -167,6 +167,8 @@ static void
 static void
     signal_bad_endpoint (client_t *self);
 static void
+    signal_failure (client_t *self);
+static void
     client_is_connected (client_t *self);
 static void
     signal_server_not_present (client_t *self);
@@ -182,8 +184,6 @@ static void
     pass_mailbox_message_to_app (client_t *self);
 static void
     pass_service_message_to_app (client_t *self);
-static void
-    signal_failure (client_t *self);
 static void
     get_first_replay_command (client_t *self);
 static void
@@ -523,14 +523,42 @@ s_client_execute (s_client_t *self, event_t event)
                             zsys_debug ("%s:         $ signal success", self->log_prefix);
                         signal_success (&self->client);
                     }
+                    if (!self->exception) {
+                        //  terminate
+                        if (mlm_client_verbose)
+                            zsys_debug ("%s:         $ terminate", self->log_prefix);
+                        self->fsm_stopped = true;
+                    }
+                }
+                else
+                if (self->event == set_producer_event) {
+                    if (!self->exception) {
+                        //  signal failure
+                        if (mlm_client_verbose)
+                            zsys_debug ("%s:         $ signal failure", self->log_prefix);
+                        signal_failure (&self->client);
+                    }
+                }
+                else
+                if (self->event == set_consumer_event) {
+                    if (!self->exception) {
+                        //  signal failure
+                        if (mlm_client_verbose)
+                            zsys_debug ("%s:         $ signal failure", self->log_prefix);
+                        signal_failure (&self->client);
+                    }
+                }
+                else
+                if (self->event == set_worker_event) {
+                    if (!self->exception) {
+                        //  signal failure
+                        if (mlm_client_verbose)
+                            zsys_debug ("%s:         $ signal failure", self->log_prefix);
+                        signal_failure (&self->client);
+                    }
                 }
                 else {
-                    //  Handle unexpected internal events
-                    zsys_warning ("%s: unhandled event %s in %s",
-                        self->log_prefix,
-                        s_event_name [self->event],
-                        s_state_name [self->state]);
-                    assert (false);
+                    //  Handle unexpected protocol events
                 }
                 break;
 


### PR DESCRIPTION
Solution: 1. when terminated in start state make sure, we are going to terminate
2. instead of crashing on unkown even, just ignore it
3. set_consumer, set_producer, set_worker should return fail, if client is not connected
4. self test extended