### PR TITLE
Problem: cannot use mlm_client_connect two times, if first time returned with error

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -426,6 +426,11 @@ mlm_client_test (bool verbose)
     rc = mlm_client_set_plain_auth (writer, "writer", "secret");
     assert (rc == 0);
     assert (mlm_client_connected (writer) == false);
+    // try to connect to server that doesn't exist
+    rc = mlm_client_connect (writer, "nonsence",1000, "writes");
+    assert (rc == -1);
+    assert (mlm_client_connected (writer) == false);
+    // try to connect to other server, that should exist.
     rc = mlm_client_connect (writer, "tcp://127.0.0.1:9999", 1000, "writer");
     assert (rc == 0);
     assert (mlm_client_connected (writer) == true);

--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -21,7 +21,7 @@
             <action name = "use connect timeout" />
             <action name = "send" message = "CONNECTION OPEN" />
         </event>
-        <event name = "bad endpoint" next = "invalid">
+        <event name = "bad endpoint">
             <action name = "signal bad endpoint" />
         </event>
         <event name = "destructor">
@@ -42,13 +42,6 @@
         </event>
         <event name = "*">
             <!-- Discard any other incoming events -->
-        </event>
-    </state>
-
-    <state name = "invalid">
-        <event name = "destructor">
-            <action name = "signal success" />
-            <action name = "terminate" />
         </event>
     </state>
 

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -25,15 +25,14 @@
 
 typedef enum {
     start_state = 1,
-    invalid_state = 2,
-    connecting_state = 3,
-    connected_state = 4,
-    confirming_state = 5,
-    disconnecting_state = 6,
-    reconnecting_state = 7,
-    disconnected_state = 8,
-    defaults_state = 9,
-    have_error_state = 10
+    connecting_state = 2,
+    connected_state = 3,
+    confirming_state = 4,
+    disconnecting_state = 5,
+    reconnecting_state = 6,
+    disconnected_state = 7,
+    defaults_state = 8,
+    have_error_state = 9
 } state_t;
 
 typedef enum {
@@ -63,7 +62,6 @@ static char *
 s_state_name [] = {
     "(NONE)",
     "start",
-    "invalid",
     "connecting",
     "connected",
     "confirming",
@@ -512,8 +510,6 @@ s_client_execute (s_client_t *self, event_t event)
                             zsys_debug ("%s:         $ signal bad endpoint", self->log_prefix);
                         signal_bad_endpoint (&self->client);
                     }
-                    if (!self->exception)
-                        self->state = invalid_state;
                 }
                 else
                 if (self->event == destructor_event) {
@@ -559,31 +555,6 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else {
                     //  Handle unexpected protocol events
-                }
-                break;
-
-            case invalid_state:
-                if (self->event == destructor_event) {
-                    if (!self->exception) {
-                        //  signal success
-                        if (mlm_client_verbose)
-                            zsys_debug ("%s:         $ signal success", self->log_prefix);
-                        signal_success (&self->client);
-                    }
-                    if (!self->exception) {
-                        //  terminate
-                        if (mlm_client_verbose)
-                            zsys_debug ("%s:         $ terminate", self->log_prefix);
-                        self->fsm_stopped = true;
-                    }
-                }
-                else {
-                    //  Handle unexpected internal events
-                    zsys_warning ("%s: unhandled event %s in %s",
-                        self->log_prefix,
-                        s_event_name [self->event],
-                        s_state_name [self->state]);
-                    assert (false);
                 }
                 break;
 


### PR DESCRIPTION
Solution: stay in "start" state if connection ended with failure