### PR TITLE
Problem: if client didn't reconnect to the server, calls set_producer

### DIFF
--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -91,6 +91,7 @@
             <action name = "signal success" />
         </event>
         <event name = "ERROR" next = "have error">
+            <action name = "signal failure" />
             <action name = "check status code" />
         </event>
     </state>

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -800,6 +800,12 @@ s_client_execute (s_client_t *self, event_t event)
                 else
                 if (self->event == error_event) {
                     if (!self->exception) {
+                        //  signal failure
+                        if (self->verbose)
+                            zsys_debug ("%s:         $ signal failure", self->log_prefix);
+                        signal_failure (&self->client);
+                    }
+                    if (!self->exception) {
                         //  check status code
                         if (self->verbose)
                             zsys_debug ("%s:         $ check status code", self->log_prefix);


### PR DESCRIPTION
, set_consumer, set_worker should return with the error.

missing test case for fast returned server.

Solution: return failure, if set producer/consumer/worked didn't work correctly
add a tst case.