### PR TITLE
Problem: released v1.0 via github

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ install(TARGETS mlm
 ########################################################################
 # pkgconfig
 ########################################################################
-set (VERSION "1.0.0")
+set (VERSION "1.1.0")
 set (prefix "${CMAKE_INSTALL_PREFIX}")
 set (exec_prefix "\${prefix}")
 set (libdir "\${prefix}/lib${LIB_SUFFIX}")

--- a/bindings/jni/README.md
+++ b/bindings/jni/README.md
@@ -32,7 +32,7 @@ Then in the android directory, run:
 This does the following:
 
 * It compiles the Malamute C sources for Android, into a native library libmlm.so in builds/android/
-* It compiles the JNI Java classes into a jar file mlm-jni-1.0.0.jar in bindings/jni/build/libs
+* It compiles the JNI Java classes into a jar file mlm-jni-1.1.0.jar in bindings/jni/build/libs
 * It compiles the JNI C sources for Android, into a native library libmlmjni.so.
 * It takes czmq-jni-*.jar, which must already be built in ../czmq/bindings/jni/build/libs/
 * It combines all these into mlm-android.jar, which you can use in your Android projects.

--- a/bindings/jni/build.gradle
+++ b/bindings/jni/build.gradle
@@ -8,7 +8,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 group = "org.zeromq"
-version = "1.0.0"
+version = "1.1.0"
 
 repositories {
     mavenLocal()

--- a/bindings/ruby/lib/malamute/ffi/version.rb
+++ b/bindings/ruby/lib/malamute/ffi/version.rb
@@ -5,7 +5,7 @@
 
 module Malamute
   module FFI
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end
 

--- a/builds/msvc/resource.rc
+++ b/builds/msvc/resource.rc
@@ -49,8 +49,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,0,0,0
- PRODUCTVERSION 1,0,0,0
+ FILEVERSION 1,1,0,0
+ PRODUCTVERSION 1,1,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -67,12 +67,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "The AUTHORS"
             VALUE "FileDescription", "ZeroMQ Message Broker"
-            VALUE "FileVersion", "1.0.0.0"
+            VALUE "FileVersion", "1.1.0.0"
             VALUE "InternalName", "Malamute"
             VALUE "LegalCopyright", "Copyright (c) the Authors"
             VALUE "OriginalFilename", "libmlm.dll"
             VALUE "ProductName", "Malamute"
-            VALUE "ProductVersion", "1.0.0.0"
+            VALUE "ProductVersion", "1.1.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ(2.61)
 #
-AC_INIT([malamute],[1.0.0],[email@hostname.com])
+AC_INIT([malamute],[1.1.0],[email@hostname.com])
 
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
@@ -36,7 +36,7 @@ AC_SUBST(PACKAGE_VERSION)
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 #
 # libmlm -version-info
-LTVER="1:0:0"
+LTVER="1:1:0"
 AC_SUBST(LTVER)
 
 # Capture c flags

--- a/include/mlm_library.h
+++ b/include/mlm_library.h
@@ -26,7 +26,7 @@
 //  MLM version macros for compile-time API detection
 
 #define MLM_VERSION_MAJOR 1
-#define MLM_VERSION_MINOR 0
+#define MLM_VERSION_MINOR 1
 #define MLM_VERSION_PATCH 0
 
 #define MLM_MAKE_VERSION(major, minor, patch) \

--- a/project.xml
+++ b/project.xml
@@ -5,7 +5,7 @@
     repository = "git://github.com/zeromq/malamute.git">
     
     <include filename = "src/license.xml" />
-    <version major = "1" minor = "0" />
+    <version major = "1" minor = "1" />
     <use project = "czmq" />
 
     <target name = "java" />


### PR DESCRIPTION
After a release we must always update the working version number
so that anyone using it does not confuse it with the released code.

Solution: update project version to 1.1