### PR TITLE
Problem: mlm_perftest.c is broken due to czmq changes

### DIFF
--- a/src/mlm_perftest.c
+++ b/src/mlm_perftest.c
@@ -68,7 +68,5 @@ int main (int argc, char *argv [])
     mlm_client_destroy (&writer);
 
     zactor_destroy (&broker);
-    printf (" -- total number of allocs: %" PRId64 ", %d/msg\n", zsys_allocs,
-            (int) (zsys_allocs / count));
     return 0;
 }


### PR DESCRIPTION
CZMQ removed zsys_allocs. Thus, we cannot use
it to check the number of allocations.

Solution: Remove it.