### PR TITLE
Problem: configure.ac systemd option had wrong help label

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -433,7 +433,7 @@ AC_SUBST([pkgconfigdir])
 
 
 # enable specific system integration features
-AC_ARG_WITH([systemd],
+AC_ARG_WITH([systemd-units],
     AS_HELP_STRING([--with-systemd-units],
     [Build and install with systemd units integration [default=no].]),
     [with_systemd_units=$withval],


### PR DESCRIPTION
Solution: zproject commit ed6d506dec fixed this.
Regenerate project.