### PR TITLE
Problem: the change from "reconneting" to "connected" state is wrong

### DIFF
--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -138,6 +138,10 @@
             <action name = "get next replay command" />
         </event>
         <event name = "replay ready" next = "connected">
+            <action name = "client is connected" />
+        </event>
+        <!-- if we receive PONG from server, we still need to wait untill replay would finsh -->
+        <event name = "CONNECTION PONG">
         </event>
     </state>
 

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -976,8 +976,17 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == replay_ready_event) {
+                    if (!self->exception) {
+                        //  client is connected
+                        if (self->verbose)
+                            zsys_debug ("%s:         $ client is connected", self->log_prefix);
+                        client_is_connected (&self->client);
+                    }
                     if (!self->exception)
                         self->state = connected_state;
+                }
+                else
+                if (self->event == connection_pong_event) {
                 }
                 else
                 if (self->event == heartbeat_event) {
@@ -989,17 +998,6 @@ s_client_execute (s_client_t *self, event_t event)
                         mlm_proto_set_id (self->message, MLM_PROTO_CONNECTION_PING);
                         mlm_proto_send (self->message, self->dealer);
                     }
-                }
-                else
-                if (self->event == connection_pong_event) {
-                    if (!self->exception) {
-                        //  client is connected
-                        if (self->verbose)
-                            zsys_debug ("%s:         $ client is connected", self->log_prefix);
-                        client_is_connected (&self->client);
-                    }
-                    if (!self->exception)
-                        self->state = connected_state;
                 }
                 else
                 if (self->event == expired_event) {


### PR DESCRIPTION
SOlution: 1. we can change  state only after all replat command were done, so if we receive PONG from server, we will state in "reconnecting state" 2. to be consistent with other links, when client goes to the "connected" state client should call "client_is_connected"