### PR TITLE
Problem: ambigous name of the function

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -366,17 +366,6 @@ check_status_code (client_t *self)
 
 
 //  ---------------------------------------------------------------------------
-//  signal_unhandled_error
-//
-
-static void
-signal_unhandled_error (client_t *self)
-{
-    zsys_error ("unhandled error code from Malamute server");
-}
-
-
-//  ---------------------------------------------------------------------------
 //  signal_server_not_present
 //
 
@@ -754,4 +743,15 @@ mlm_client_test (bool verbose)
     zactor_destroy (&server);
     //  @end
     printf ("OK\n");
+}
+
+
+//  ---------------------------------------------------------------------------
+//  announce_unhandled_error
+//
+
+static void
+announce_unhandled_error (client_t *self)
+{
+    zsys_error ("unhandled error code from Malamute server");
 }

--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -197,7 +197,7 @@
             <action name = "terminate" />
         </event>
         <event name = "other">
-            <action name = "signal unhandled error" />
+            <action name = "announce unhandled error" />
             <action name = "terminate" />
         </event>
     </state>

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -194,7 +194,7 @@ static void
 static void
     get_next_replay_command (client_t *self);
 static void
-    signal_unhandled_error (client_t *self);
+    announce_unhandled_error (client_t *self);
 
 //  Create a new client connection
 
@@ -1184,10 +1184,10 @@ s_client_execute (s_client_t *self, event_t event)
                 else
                 if (self->event == other_event) {
                     if (!self->exception) {
-                        //  signal unhandled error
+                        //  announce unhandled error
                         if (self->verbose)
-                            zsys_debug ("%s:         $ signal unhandled error", self->log_prefix);
-                        signal_unhandled_error (&self->client);
+                            zsys_debug ("%s:         $ announce unhandled error", self->log_prefix);
+                        announce_unhandled_error (&self->client);
                     }
                     if (!self->exception) {
                         //  terminate


### PR DESCRIPTION
SOlution: rename it

all other signal* functions are designed to send a
replay back to the caller API, but signal_unhandled_error
is not.