### PR TITLE
Fix compilation with mingw64 using autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,7 +209,7 @@ AC_MSG_CHECKING([whether to install manpages])
 AC_MSG_RESULT([$malamute_install_man])
 
 # Set some default features required by libmlm code.
-CPPFLAGS="-D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
+CPPFLAGS="-DMLM_INTERNAL_BUILD -D_REENTRANT -D_THREAD_SAFE $CPPFLAGS"
 
 # OS-specific tests
 case "${host_os}" in
@@ -264,6 +264,16 @@ case "${host_os}" in
         AC_DEFINE(MLM_HAVE_HPUX, 1, [Have HPUX OS])
         ;;
     *mingw32*)
+        AC_DEFINE(MLM_HAVE_WINDOWS, 1, [Have Windows OS])
+        AC_DEFINE(MLM_HAVE_MINGW32, 1, [Have MinGW32])
+        AC_CHECK_HEADERS(windows.h)
+        malamute_on_mingw32="yes"
+        malamute_install_man="no"
+        ;;
+    *mingw64*)
+        # Define on MINGW64 to enable all libeary features
+        # Disable format error due to incomplete ANSI C
+        CPPFLAGS="-Wno-error=format -D_XOPEN_SOURCE $CPPFLAGS"
         AC_DEFINE(MLM_HAVE_WINDOWS, 1, [Have Windows OS])
         AC_DEFINE(MLM_HAVE_MINGW32, 1, [Have MinGW32])
         AC_CHECK_HEADERS(windows.h)

--- a/include/mlm_library.h
+++ b/include/mlm_library.h
@@ -36,6 +36,12 @@
 #if defined (__WINDOWS__)
 #   if defined MLM_STATIC
 #       define MLM_EXPORT
+#   elif defined MLM_INTERNAL_BUILD
+#       if defined DLL_EXPORT
+#           define MLM_EXPORT __declspec(dllexport)
+#       else
+#           define MLM_EXPORT __declspec(dllexport)
+#       endif
 #   elif defined MLM_EXPORTS
 #       define MLM_EXPORT __declspec(dllexport)
 #   else


### PR DESCRIPTION
HI,
Here the fixes for correctly compile malamute using msys2 + mingw64 gcc.
DLL_EXPORT is automatically generated by libtool. I'm using this symbol + the indication of internal compilation put in the configure.ac in order to enable dllexport or not