### PR TITLE
Problem: someclient are trying to reconnect with wrong address

### DIFF
--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -189,6 +189,7 @@
 
     <state name = "have error">
         <event name = "command invalid" next = "reconnecting">
+            <action name = "set client address" />
             <action name = "use connect timeout" />
             <action name = "send" message = "CONNECTION OPEN" />
         </event>

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -1150,6 +1150,12 @@ s_client_execute (s_client_t *self, event_t event)
             case have_error_state:
                 if (self->event == command_invalid_event) {
                     if (!self->exception) {
+                        //  set client address
+                        if (self->verbose)
+                            zsys_debug ("%s:         $ set client address", self->log_prefix);
+                        set_client_address (&self->client);
+                    }
+                    if (!self->exception) {
                         //  use connect timeout
                         if (self->verbose)
                             zsys_debug ("%s:         $ use connect timeout", self->log_prefix);


### PR DESCRIPTION
Solution: set up the address in the message before reconnect to the right value
because field "address" in mlm_proto is used not only for client address set up