### PR TITLE
Problem: address of the client can disappear

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -35,6 +35,7 @@ typedef struct {
     client_args_t *args;        //  Arguments from methods
 
     //  Own properties
+    char *myaddress;            //  Address of client mailbox
     int heartbeat_timer;        //  Timeout for heartbeats to server
     zlistx_t *replays;          //  Replay server-side state set-up
 } client_t;
@@ -119,6 +120,7 @@ static void
 client_terminate (client_t *self)
 {
     zlistx_destroy (&self->replays);
+    zstr_free (&self->myaddress);
 }
 
 
@@ -155,7 +157,19 @@ connect_to_server_endpoint (client_t *self)
 static void
 set_client_address (client_t *self)
 {
-    mlm_proto_set_address (self->message, self->args->address);
+    mlm_proto_set_address (self->message, self->myaddress);
+}
+
+//  ---------------------------------------------------------------------------
+//  remember_client_address
+//
+
+static void
+remember_client_address (client_t *self)
+{
+    free(self->myaddress);
+    self->myaddress = strdup (self->args->address);
+    zsys_info ("My address is '%s'", self->myaddress);
 }
 
 

--- a/src/mlm_client.xml
+++ b/src/mlm_client.xml
@@ -16,6 +16,8 @@
             <action name = "signal success" />
         </event>
         <event name = "connect" next = "connecting">
+            <!-- This action should be called before "set client address" -->
+            <action name = "remember client address" />
             <action name = "connect to server endpoint" />
             <action name = "set client address" />
             <action name = "use connect timeout" />

--- a/src/mlm_client_engine.inc
+++ b/src/mlm_client_engine.inc
@@ -160,6 +160,8 @@ static void
 static void
     signal_success (client_t *self);
 static void
+    remember_client_address (client_t *self);
+static void
     connect_to_server_endpoint (client_t *self);
 static void
     set_client_address (client_t *self);
@@ -472,6 +474,12 @@ s_client_execute (s_client_t *self, event_t event)
                 }
                 else
                 if (self->event == connect_event) {
+                    if (!self->exception) {
+                        //  remember client address
+                        if (self->verbose)
+                            zsys_debug ("%s:         $ remember client address", self->log_prefix);
+                        remember_client_address (&self->client);
+                    }
                     if (!self->exception) {
                         //  connect to server endpoint
                         if (self->verbose)


### PR DESCRIPTION
Solution: store client's address as a separate field in the structure
instead of storing it in self->args->address (because it  could be rewritten
by the call set_worker)