### PR TITLE
PROBLEM: Can't query names of connected clients 

### DIFF
--- a/include/mlm_server.h
+++ b/include/mlm_server.h
@@ -77,6 +77,11 @@ extern "C" {
 //
 //      zmsg_t *msg = zactor_recv (mlm_server);
 //
+//  Receive names of connected clients as multipart string message,
+//  where first frame (string) is repeated command (CLIENTLIST in this case):
+//
+//      zstr_sendx (mlm_server, "CLIENTLIST", NULL);
+//
 //  This is the mlm_server constructor as a zactor_fn:
 //
 MLM_EXPORT void

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -322,6 +322,16 @@ server_terminate (server_t *self)
 static zmsg_t *
 server_method (server_t *self, const char *method, zmsg_t *msg)
 {
+    if (streq (method, "CLIENTLIST")) {
+        zmsg_t *reply = zmsg_new ();
+        zmsg_addstr (reply, "CLIENTLIST");
+        void *item = zhashx_first (self->clients);
+        while (item) {
+            zmsg_addstr (reply, (const char *) zhashx_cursor (self->clients));
+            item = (void *) zhashx_next (self->clients);
+        }
+        return reply;
+    }
     return NULL;
 }
 


### PR DESCRIPTION
Currently there is no way how to find out names of clients connected
to malamute server.

SOLUTION: Create malamute server (actor) command CLIENTLIST that
returns multipart string message with connected client names and
repeated command  as first frame.