### PR TITLE
Problem: private classes self tests no longer ran

### DIFF
--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -987,4 +987,12 @@ mlm_server_test (bool verbose)
 
     //  @end
     printf ("OK\n");
+
+    // mlm_msg, mlm_stream_simple, mlm_mailbox_simple and mlm_mailbox_bounded
+    // are private classes and symbols are not exported so the tests can't be
+    // run from mlm_selftest, so run them from here
+    mlm_msg_test (verbose);
+    mlm_stream_simple_test (verbose);
+    mlm_mailbox_simple_test (verbose);
+    mlm_mailbox_bounded_test (verbose);
 }


### PR DESCRIPTION
Solution: given the private classes symbols are intentionally not
exported, the self test functions cannot be called from the external
mlm_selftest binary.
Call them instead from the main class selftest function.