### PR TITLE
Problem: out of date with zproject

### DIFF
--- a/packaging/debian/malamute.dsc.obs
+++ b/packaging/debian/malamute.dsc.obs
@@ -9,7 +9,6 @@ Build-Depends: debhelper (>= 9),
     dh-autoreconf,
     libzmq3-dev,
     libczmq-dev,
-# necessary for systemd.pc to get unit install path
     systemd,
     dh-systemd,
 Build-Depends-Indep: asciidoc,


### PR DESCRIPTION
Solution: regenerate

Comments can go inline in d/control but not in the .dsc. Ops.