### PR TITLE
Problem: want to play with meson build system

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,47 @@
+#
+# This is experimental meson build script for malamute
+# written by hand in order to learn as much of it to replace
+# autotools backend
+#
+# TODO:
+#  * unit test fail
+#  * do not install pc files et all
+#  * do not know concept of DRAFTS
+#  * cannot add DRAFT macros to config.h
+#  * do not install systemd files (which might be good BTW)
+#  * you can't turn binaries on and off
+#  * does not have optional dependencies
+#  * don't have an ability to call (make code)
+#  * no integration with Travis
+#  * no memcheck target
+#
+project ('malamute', 'c')
+
+# dependencies
+zmqdep = dependency ('libzmq', version: '>=4.2.0')
+czmqdep = dependency ('libczmq', version: '>=3.0.0')
+
+LIBS = [
+    zmqdep,
+    czmqdep
+    ]
+
+# shared library sources
+MLM_SRC = [
+    'src/mlm_msg.c',
+    'src/mlm_stream_simple.c',
+    'src/mlm_mailbox_simple.c',
+    'src/mlm_mailbox_bounded.c',
+    'src/platform.h',
+    'src/mlm_proto.c',
+    'src/mlm_server.c',
+    'src/mlm_client.c',
+    'src/mlm_selftest.c',
+    'src/mlm_private_selftest.c',
+    ]
+
+libmlm = shared_library ('mlm', MLM_SRC, version: '1.0.0', soversion: '0', dependencies: LIBS)
+
+executable ('malamute', 'src/malamute.c', link_with: [libmlm], dependencies: LIBS)
+mlm_selftest = executable ('mlm_selftest', 'src/mlm_selftest.c', link_with: [libmlm], dependencies: LIBS)
+test ('mlm_selftest', mlm_selftest)


### PR DESCRIPTION
Solution: write a basic meson.build file for malamute by hand, note
number of issues and push it upstream.

meson build is a generator (like CMake or zproject) of build recipes. It
uses ninja backend by default, but have an ability to generate builds
for MSVC and XCode. Like zproject it's quite opiniated and declarative
(unline WAF) and easy to write (unline CMake), so can be a great
match.

How to use:
    mkdir build
    meson . build/
    ninja -v -C build
    ninja -v -C build test

The final goal is to get zproject_meson.gsl, so this will give people
option to play with it.