### PR TITLE
Problem: redundant strdup ()/zstr_free () in register_client ()

### DIFF
--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -449,8 +449,6 @@ register_new_client (client_t *self)
     if (*self->address) {
         //  If there's an existing client with this address, expire it
         //  The alternative would be to reject new clients with the same address
-        zstr_free (&self->address);
-        self->address = strdup (mlm_proto_address (self->message));
         client_t *existing = (client_t *) zhashx_lookup (
             self->server->clients, self->address);
         if (existing)

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -446,6 +446,7 @@ static void
 register_new_client (client_t *self)
 {
     self->address = strdup (mlm_proto_address (self->message));
+    //  We ignore anonymous clients, which have empty addresses
     if (*self->address) {
         //  If there's an existing client with this address, expire it
         //  The alternative would be to reject new clients with the same address


### PR DESCRIPTION
I see that commit 5d4a792 introduced the second strdup and d508a95 introduced zstr_free () before the second strdup (). 

@vyskocilm As you were the last to change this part, do you see a reason for keeping this?