### PR TITLE
Improve tests

### DIFF
--- a/src/mlm_client.c
+++ b/src/mlm_client.c
@@ -403,7 +403,7 @@ signal_server_not_present (client_t *self)
 void
 mlm_stream_api_test (bool verbose)
 {
-    const char *endpoint = "ipc://mlm_stream_api_server";
+    const char *endpoint = "inproc://mlm_stream_api_server";
     char *subject, *content;
     int rc;
 
@@ -543,7 +543,7 @@ mlm_service_api_test (bool verbose)
         rc = zstr_send (server, "VERBOSE");
         assert (rc == 0);
     }
-    const char *endpoint = "ipc://mlm_service_api_server";
+    const char *endpoint = "inproc://mlm_service_api_server";
     rc = zstr_sendx (server, "BIND", endpoint, NULL);
     assert (rc == 0);
 
@@ -635,7 +635,7 @@ mlm_services_api_test (bool verbose)
         rc = zstr_send (server, "VERBOSE");
         assert (rc == 0);
     }
-    const char *endpoint = "ipc://mlm_services_api_server";
+    const char *endpoint = "inproc://mlm_services_api_server";
     rc = zstr_sendx (server, "BIND", endpoint, NULL);
     assert (rc == 0);
 

--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -1182,12 +1182,4 @@ mlm_server_test (bool verbose)
 
     //  @end
     printf ("OK\n");
-
-    // mlm_msg, mlm_stream_simple, mlm_mailbox_simple and mlm_mailbox_bounded
-    // are private classes and symbols are not exported so the tests can't be
-    // run from mlm_selftest, so run them from here
-    mlm_msg_test (verbose);
-    mlm_stream_simple_test (verbose);
-    mlm_mailbox_simple_test (verbose);
-    mlm_mailbox_bounded_test (verbose);
 }


### PR DESCRIPTION
Issue:
Some tests doesn't run on windows (cause: IPC)
Private class tests are now includes as a seperate test
For some reason NDEBUG is undefined (For enabling test in release? if it is the case it's an incomplete and a hacky solution)
On windows each test crash at the end because wsacleanup is called before zsys_shutdown (called by atexit)

Done:
Use inproc instead of ipc for tests (Windows compatibility)
Remove duplicated tests
Remove NDEBUG undef

Todo:
Find a way to call zsys_shutdown at the end of each tests?
Use another assert function always enabled in the test part of the code?