### PR TITLE
Fix zap auth with plain mechanism

### DIFF
--- a/src/mlm_client.cfg
+++ b/src/mlm_client.cfg
@@ -14,5 +14,6 @@ server
 mlm_server
     security
         mechanism = plain
+        domain = test
     bind
         endpoint = tcp://127.0.0.1:9999

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -1447,10 +1447,10 @@ s_server_config_service (s_server_t *self)
         if (streq (zconfig_name (section), "security")) {
             char *mechanism = zconfig_get (section, "mechanism", "null");
             char *domain = zconfig_get (section, "domain", NULL);
+            if (domain)
+                zsock_set_zap_domain (self->router, domain);
             if (streq (mechanism, "null")) {
                 zsys_notice ("server is using NULL security");
-                if (domain)
-                    zsock_set_zap_domain (self->router, NULL);
             }
             else
             if (streq (mechanism, "plain")) {


### PR DESCRIPTION
I'm not sure that the commit is correct, but since this commit https://github.com/zeromq/libzmq/commit/e546f9296e6002c0b3311c98cd5e308d3757807f
You must provide a domain for plain mechanism.