### PR TITLE
Properly handle pending stream traffic after client disconnect

### DIFF
--- a/src/mlm_server.c
+++ b/src/mlm_server.c
@@ -376,6 +376,15 @@ server_method (server_t *self, const char *method, zmsg_t *msg)
         }
         return reply;
     }
+    if (streq (method, "SLOW_TEST_MODE")) {
+        //  selftest: Tell all stream engines to enable SLOW_TEST_MODE
+        stream_t *stream = (stream_t *) zhashx_first (self->streams);
+        while (stream) {
+            zsock_send (stream->actor, "s", method);
+            stream = (stream_t *) zhashx_next (self->streams);
+        }
+        return NULL;
+    }
     return NULL;
 }
 
@@ -1186,6 +1195,37 @@ mlm_server_test (bool verbose)
 
         mlm_proto_destroy (&proto);
         zsock_destroy (&reader);
+        zactor_destroy (&server);
+    }
+
+    {
+        const char *endpoint = "inproc://mlm_server_disconnect_pending_stream_traffic";
+        zactor_t *server = zactor_new (mlm_server, "mlm_server_disconnect_pending_stream_traffic");
+        if (verbose) {
+            zstr_send (server, "VERBOSE");
+            printf("Regression test for use-after-free with pending stream traffic after disconnect\n");
+        }
+        zstr_sendx (server, "BIND", endpoint, NULL);
+
+        mlm_client_t *producer = mlm_client_new ();
+        assert (mlm_client_connect (producer, endpoint, 1000, "producer") >= 0);
+        assert (mlm_client_set_producer (producer, "STREAM_TEST") >= 0);
+
+        zstr_sendx (server, "SLOW_TEST_MODE", NULL);
+
+        mlm_client_t *consumer = mlm_client_new ();
+        assert (mlm_client_connect (consumer, endpoint, 1000, "consumer") >= 0);
+        assert (mlm_client_set_consumer (consumer, "STREAM_TEST", ".*") >= 0);
+
+        zmsg_t *msg = zmsg_new ();
+        zmsg_addstr (msg, "world");
+        assert (mlm_client_send (producer, "hello", &msg) >= 0);
+
+        mlm_client_destroy (&consumer);
+
+        zclock_sleep (2000);
+
+        mlm_client_destroy (&producer);
         zactor_destroy (&server);
     }
 

--- a/src/mlm_server_engine.inc
+++ b/src/mlm_server_engine.inc
@@ -32,7 +32,9 @@ typedef enum {
     start_state = 1,
     connected_state = 2,
     defaults_state = 3,
-    settling_state = 4
+    settling_state = 4,
+    //  Internal state to mark zombie clients
+    zombie_state_ = 5
 } state_t;
 
 typedef enum {
@@ -105,6 +107,7 @@ typedef struct {
     zloop_t *loop;              //  Reactor for server sockets
     mlm_proto_t *message;       //  Message received or sent
     zhash_t *clients;           //  Clients we're connected to
+    zhash_t *zombies;           //  Zombie clients waiting to be free()d
     zconfig_t *config;          //  Configuration tree
     uint client_id;             //  Client identifier counter
     size_t timeout;             //  Default client expiry timeout
@@ -121,6 +124,7 @@ typedef struct {
 typedef struct {
     client_t client;            //  Application-level client context
     s_server_t *server;         //  Parent server context
+    size_t refcount;            //  Optional reference counter
     char *hashkey;              //  Key into server->clients hash
     zframe_t *routing_id;       //  Routing_id back to client
     uint unique_id;             //  Client identifier in server
@@ -154,6 +158,8 @@ static int
     s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
 static int
     s_client_handle_ticket (zloop_t *loop, int timer_id, void *argument);
+static void
+    s_client_finalize (s_client_t **self_p);
 static void
     register_new_client (client_t *self);
 static void
@@ -198,6 +204,31 @@ static void
 //  ---------------------------------------------------------------------------
 //  These methods are an internal API for actions
 
+//  Optional reference counting. The engine itself does not need this, but if
+//  the application wishes to delay the final destruction of a client, it
+//  can do so by using these functions
+static void engine_client_get (client_t *client)
+{
+    if (!client)
+        return;
+    s_client_t *self = (s_client_t *) client;
+    ++self->refcount;
+}
+
+//  Relese the application reference to client
+static void engine_client_put (client_t *client)
+{
+    if (!client)
+        return;
+    s_client_t *self = (s_client_t *) client;
+    if (--self->refcount == 0 && self->state == zombie_state_) {
+        zhash_delete (self->server->zombies, self->hashkey);
+        s_client_finalize (&self);
+    }
+}
+
+#define engine_client_is_valid(c) ((c) && ((s_client_t *)(c))->state != zombie_state_)
+
 //  Set the next event, needed in at least one action in an internal
 //  state; otherwise the state machine will wait for a message on the
 //  router socket and treat that as the event.
@@ -205,7 +236,7 @@ static void
 static void
 engine_set_next_event (client_t *client, event_t event)
 {
-    if (client) {
+    if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
         self->next_event = event;
     }
@@ -217,7 +248,7 @@ engine_set_next_event (client_t *client, event_t event)
 static void
 engine_set_exception (client_t *client, event_t event)
 {
-    if (client) {
+    if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
         self->exception = event;
     }
@@ -230,7 +261,7 @@ engine_set_exception (client_t *client, event_t event)
 static void
 engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
 {
-    if (client) {
+    if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
         if (self->wakeup) {
             zloop_timer_end (self->server->loop, self->wakeup);
@@ -248,7 +279,7 @@ engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
 static void
 engine_send_event (client_t *client, event_t event)
 {
-    if (client) {
+    if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
         s_client_execute (self, event);
     }
@@ -332,7 +363,7 @@ engine_cancel_monitor (server_t *server, int identifier)
 static void
 engine_set_log_prefix (client_t *client, const char *string)
 {
-    if (client) {
+    if (engine_client_is_valid (client)) {
         s_client_t *self = (s_client_t *) client;
         snprintf (self->log_prefix, sizeof (self->log_prefix),
             "%6d:%-33s", self->unique_id, string);
@@ -371,6 +402,8 @@ engine_verbose (server_t *server)
 static void
 s_satisfy_pedantic_compilers (void)
 {
+    engine_client_get (NULL);
+    engine_client_put (NULL);
     engine_set_next_event (NULL, NULL_event);
     engine_set_exception (NULL, NULL_event);
     engine_set_wakeup_event (NULL, 0, NULL_event);
@@ -481,11 +514,23 @@ s_client_destroy (s_client_t **self_p)
         zframe_destroy (&self->routing_id);
         //  Provide visual clue if application misuses client reference
         engine_set_log_prefix (&self->client, "*** TERMINATED ***");
-        client_terminate (&self->client);
-        free (self->hashkey);
-        free (self);
-        *self_p = NULL;
+        if (!self->refcount) {
+            s_client_finalize (self_p);
+        } else {
+            zhash_insert (self->server->zombies, self->hashkey, self);
+            self->state = zombie_state_;
+        }
     }
+}
+
+static void
+s_client_finalize (s_client_t **self_p)
+{
+    s_client_t *self = *self_p;
+    free (self->hashkey);
+    client_terminate (&self->client);
+    free (self);
+    *self_p = NULL;
 }
 
 //  Callback when we remove client from 'clients' hash table
@@ -1302,6 +1347,9 @@ s_client_execute (s_client_t *self, event_t event)
                     }
                 }
                 break;
+            case zombie_state_:
+                zsys_error ("%p: zombie client context used", self);
+                return;
         }
         //  If we had an exception event, interrupt normal programming
         if (self->exception) {
@@ -1389,6 +1437,7 @@ s_server_new (zsock_t *pipe)
     zsock_set_unbounded (self->router);
     self->message = mlm_proto_new ();
     self->clients = zhash_new ();
+    self->zombies = zhash_new ();
     self->config = zconfig_new ("root", NULL);
     self->loop = zloop_new ();
     srandom ((unsigned int) zclock_time ());
@@ -1413,6 +1462,13 @@ s_server_destroy (s_server_t **self_p)
         mlm_proto_destroy (&self->message);
         //  Destroy clients before destroying the server
         zhash_destroy (&self->clients);
+        //  Forcibly destroy any zombie clients as we are shutting down
+        s_client_t *zombie = (s_client_t *)zhash_first (self->zombies);
+        while (zombie) {
+            s_client_finalize (&zombie);
+            zombie = (s_client_t *)zhash_next (self->zombies);
+        }
+        zhash_destroy (&self->zombies);
         server_terminate (&self->server);
         zsock_destroy (&self->router);
         zconfig_destroy (&self->config);

--- a/src/mlm_stream_simple.c
+++ b/src/mlm_stream_simple.c
@@ -174,6 +174,7 @@ s_stream_engine_handle_command (stream_engine_t *self)
         void *client;
         zsock_recv (self->cmdpipe, "p", &client);
         s_stream_engine_cancel (self, client);
+        zsock_bsend (self->msgpipe, "pp", client, MLM_STREAM_ACK_CANCEL);
     }
     //  Cleanup pipe if any argument frames are still waiting to be eaten
     if (zsock_rcvmore (self->cmdpipe)) {

--- a/src/mlm_stream_simple.c
+++ b/src/mlm_stream_simple.c
@@ -72,6 +72,7 @@ typedef struct {
     zpoller_t *poller;          //  Socket poller
     bool terminated;            //  Did caller ask us to quit?
     bool verbose;               //  Verbose logging enabled?
+    bool slow_test_mode;        //  Insert sleeps to test for races
     zlistx_t *selectors;        //  List of selectors we hold
 } stream_engine_t;
 
@@ -176,6 +177,10 @@ s_stream_engine_handle_command (stream_engine_t *self)
         s_stream_engine_cancel (self, client);
         zsock_bsend (self->msgpipe, "pp", client, MLM_STREAM_ACK_CANCEL);
     }
+    else
+    if (streq (method, "SLOW_TEST_MODE")) {
+        self->slow_test_mode = true;
+    }
     //  Cleanup pipe if any argument frames are still waiting to be eaten
     if (zsock_rcvmore (self->cmdpipe)) {
         zsys_error ("mlm_stream_simple: trailing API command frames (%s)", method);
@@ -194,6 +199,9 @@ s_stream_engine_handle_message (stream_engine_t *self)
     void *sender;
     mlm_msg_t *msg;
     zsock_brecv (self->msgpipe, "pp", &sender, &msg);
+
+    if (self->slow_test_mode)
+        zclock_sleep (1500);
 
     selector_t *selector = (selector_t *) zlistx_first (self->selectors);
     while (selector) {

--- a/src/mlm_stream_simple.h
+++ b/src/mlm_stream_simple.h
@@ -37,6 +37,10 @@ extern "C" {
 MLM_EXPORT void
     mlm_stream_simple (zsock_t *pipe, void *args);
 
+//  Magic cookie signaling that the stream engine has dropped references to
+//  a given client
+#define MLM_STREAM_ACK_CANCEL ((void *)1)
+
 //  Self test of this class
 MLM_EXPORT void
     mlm_stream_simple_test (bool verbose);


### PR DESCRIPTION
The current code inserts a one second delay in the hope that any pending
stream traffic will be flushed before the client context is destroyed.
Under heavy load, this may not work and we end up with a use-after-free
in s_forward_stream_traffic(). Instead of relying on luck, do proper
reference counting on the client contexts.