### PR TITLE
Problem: Windows DLL builds cannot run zsys_shutdown in at_exit

### DIFF
--- a/src/malamute.c
+++ b/src/malamute.c
@@ -139,5 +139,10 @@ int main (int argc, char *argv [])
 
     //  Destroy config tree
     zconfig_destroy (&config);
+
+#if defined (__WINDOWS__)
+    zsys_shutdown ();
+#endif
+
     return 0;
 }


### PR DESCRIPTION
Solution: call it manually before exiting