### PR TITLE
Use environment variable instead of hardcoded zsys config

### DIFF
--- a/src/malamute.c
+++ b/src/malamute.c
@@ -64,9 +64,11 @@ int main (int argc, char *argv [])
         config_file = argv [argn];
         argn++;
     }
-    //  Send logging to system facility as well as stdout
     zsys_init ();
-    zsys_set_logsystem (true);
+    // Keep old behavior unless specified otherwise.
+    if (!getenv ("ZSYS_LOGSYSTEM")) {
+        zsys_set_logsystem(true);
+    }
     zsys_set_pipehwm (0);
     zsys_set_sndhwm (0);
     zsys_set_rcvhwm (0);


### PR DESCRIPTION
zsys already allow `ZSYS_LOGSYSTEM` and `ZSYS_LOGSTREAM` to control this behavior. However the `zsys_set_logsystem` override those and does not leave any way for the user to use `ZSYS_LOGSYSTEM=false`. Note that unlike as stated by the previous comment, stdout is only used if logsystem is not used.