### PR TITLE
src/libmlm.pc.in: make .pc.in relocatable by using pcfiledir variable

### DIFF
--- a/src/libmlm.pc.in
+++ b/src/libmlm.pc.in
@@ -3,7 +3,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 
-prefix=@prefix@
+prefix=${pcfiledir}/../..
 exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@


### PR DESCRIPTION
This PR makes the `.pc` file relocatable. I'm not sure if `exec_prefix` needs to be modified as well.