### PR TITLE
Problem: `./mlm_selftest` can't find .cfg files in `mlm_client` selftests and fails

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,16 @@ if (NOT TARGET make-selftest-rw)
     )
 endif()
 
+# mlm_client's selftests rely on /src/ references for .cfg files
+# this is needed when running from ./mlm_selftest copy them to the build/binary dir
+configure_file(
+    "${CMAKE_SOURCE_DIR}/src/mlm_client.cfg"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/mlm_client.cfg"
+@ONLY)
+configure_file(
+    "${CMAKE_SOURCE_DIR}/src/passwords.cfg"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/passwords.cfg"
+@ONLY)
 
 set_directory_properties(
     PROPERTIES


### PR DESCRIPTION
Solution: Add `configure_file` calls to CMakeLists

----------------

**WARNING: This modifies a [zproject](https://github.com/zeromq/zproject) generated file.** 

This is meant as a quick-fix for those stump as to why mlm_client selftest fails with the following when executing `mlm_selftest`
```
 * mlm_client:
W: 24-03-27 13:53:44 cannot load config file 'src/mlm_client.cfg'
I: 24-03-27 13:53:44 My address is 'client_robust'
mlm_selftest: /home/brian/malamute/src/mlm_client.c:897: mlm_client_test: Assertion `rc == 0' failed.
```

When running cmake from clion IDE, the default behavior is that `mlm_selftest` is it's own test project you can execute, but when doing so the authorization fails (relating to not finding .cfg). I have yet to dive into the depths of how this could be done with zproject properly, and I tried implementing the suggestion of moving them to `/src/selftests_ro`  ( https://github.com/zeromq/malamute/issues/272 ) but that was honestly a lot of changes and they wouldn't of been valid anyways since they were modifying zproject generated files.

Not reading in `mlm_client.cfg` failed gracefully with a warning, but sending `PLAIN`to the auth actor with non-existant `passwords.cfg` is out the scope of malamute (different repo) but would be nice if it also warned.